### PR TITLE
📈 Streaming Firestore collections to Bigquery #40

### DIFF
--- a/libs/analytics/data-schemas/accounts.view.sql
+++ b/libs/analytics/data-schemas/accounts.view.sql
@@ -3,9 +3,29 @@ SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
   JSON_EXTRACT_SCALAR(data, '$.id') AS id,
 
+  JSON_EXTRACT_SCALAR(data, '$.accountHolder') AS holder_name,
+  JSON_EXTRACT_SCALAR(data, '$.accountHolderEmail') AS holder_email,
+  JSON_EXTRACT_SCALAR(data, '$.accountHolderPhone') AS holder_phone,
 
-  JSON_EXTRACT_SCALAR(data, '$.accountHolder') AS name,
+  JSON_EXTRACT_SCALAR(data, '$.name') AS account_name,
+  JSON_EXTRACT_SCALAR(data, '$.desc') AS account_desc,
+  JSON_EXTRACT_SCALAR(data, '$.currency') AS account_currency,
+  JSON_EXTRACT_SCALAR(data, '$.trType') AS transaction_type,
+
   JSON_EXTRACT_SCALAR(data, '$.accountHolderAddress.city') AS address_city,
- 
+  JSON_EXTRACT_SCALAR(data, '$.accountHolderAddress.country') AS address_country,
+  JSON_EXTRACT_SCALAR(data, '$.accountHolderAddress.physicalAddress') AS physical_address,
+  JSON_EXTRACT_SCALAR(data, '$.accountHolderAddress.postalAddress') AS postal_address,
+  JSON_EXTRACT_SCALAR(data, '$.accountHolderAddress.postalCode') AS postal_code,
+  JSON_EXTRACT_SCALAR(data, '$.accountHolderAddress.streetName') AS address_street,
 
-FROM `project-kujali.kdev.accounts_raw_latest`
+  CAST(JSON_EXTRACT( data , '$.bankConnection') as INT64) AS bank_connection,
+
+  JSON_EXTRACT_SCALAR(data, '$.bic') AS bic,
+  JSON_EXTRACT_SCALAR(data, '$.iban') AS iban,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
+
+FROM `project-kujali.kdev.kdev_accounts_raw_latest`

--- a/libs/analytics/data-schemas/allocs.view.sql
+++ b/libs/analytics/data-schemas/allocs.view.sql
@@ -1,0 +1,14 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  
+  CAST(JSON_EXTRACT( data , '$.amount') as FLOAT64) AS amount,
+
+  JSON_EXTRACT_SCALAR(data, '$.invId') AS invoice_id,
+  JSON_EXTRACT_SCALAR(data, '$.pId') AS payment_id,
+
+  CAST(JSON_EXTRACT(data , '$.trType') as INT64) AS transaction_type,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_allocs_raw_latest`

--- a/libs/analytics/data-schemas/bank_connections.view.sql
+++ b/libs/analytics/data-schemas/bank_connections.view.sql
@@ -1,0 +1,28 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  JSON_EXTRACT_SCALAR(data, '$.name') AS name,
+
+  JSON_EXTRACT_SCALAR(data, '$.paymentsActivationUrl') AS payments_activation_url,
+  CAST(JSON_EXTRACT(data, '$.paymentsActivated') as BOOL) AS payments_activated,
+
+  CAST(JSON_EXTRACT(accounts, '$.active') as BOOL) AS account_active,
+  JSON_EXTRACT_SCALAR(accounts, '$.bankAccId') AS bank_account_id,
+  JSON_EXTRACT_SCALAR(accounts, '$.sysAccId') AS sys_account_id,
+  JSON_EXTRACT_SCALAR(accounts, '$.sysAccName') AS sys_account_name,
+  CAST(JSON_EXTRACT(accounts, '$.status') as INT64) AS account_status,
+  CAST(JSON_EXTRACT(accounts, '$.type') as INT64) AS account_type,
+  JSON_EXTRACT_SCALAR(accounts, '$.iban') AS iban,
+
+  JSON_EXTRACT_SCALAR(accounts, '$.originalAccountInstance.attributes.holderName') AS account_holder,
+  JSON_EXTRACT_SCALAR(accounts, '$.originalAccountInstance.attributes.currency') AS account_currency,
+
+  JSON_EXTRACT_SCALAR(data, '$.status') AS status,
+  CAST(JSON_EXTRACT(data, '$.type') as INT64) AS connection_type,
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
+
+FROM `project-kujali.kdev.kdev_bank_connections_raw_latest`,
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.accounts')) AS accounts

--- a/libs/analytics/data-schemas/bank_connections_access_info.view.sql
+++ b/libs/analytics/data-schemas/bank_connections_access_info.view.sql
@@ -1,0 +1,22 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(path_params, '$.connectionid') AS connection_id,
+
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  CAST(JSON_EXTRACT(data , '$.status') as INT64) AS status,
+  
+  JSON_EXTRACT_SCALAR(data, '$.userAccess.access_token') AS access_token,
+  CAST(JSON_EXTRACT(data , '$.userAccess.expires_in') as INT64) AS expires_in,
+  JSON_EXTRACT_SCALAR(data, '$.userAccess.refresh_token') as refresh_token,
+  JSON_EXTRACT_SCALAR(data, '$.userAccess.scope') AS scope,
+  JSON_EXTRACT_SCALAR(data, '$.userAccess.token_type') AS token_type,
+
+  CAST(JSON_EXTRACT(data , '$.version') as INT64) AS version,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
+
+FROM `project-kujali.kdev.kdev_bank_connections_access_info_raw_latest`
+

--- a/libs/analytics/data-schemas/budget_config.view.sql
+++ b/libs/analytics/data-schemas/budget_config.view.sql
@@ -1,0 +1,12 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(path_params, '$.budgetid') AS budget_id,
+
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  CAST(JSON_EXTRACT(data, '$.isbudgetLocked') as BOOL) AS is_budget_locked,
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
+
+FROM `project-kujali.kdev.kdev_budget_config_raw_latest`

--- a/libs/analytics/data-schemas/budget_headers.view.sql
+++ b/libs/analytics/data-schemas/budget_headers.view.sql
@@ -1,4 +1,4 @@
---TO BE UPDATED ONCE THE budget_headers collection is normalized
+--TO BE UPDATED ONCE THE "budget_headers" COLLECTION HAS BEEN NORMALIZED
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
   JSON_EXTRACT_SCALAR(path_params, '$.budgetid') AS budget_id,

--- a/libs/analytics/data-schemas/budget_headers.view.sql
+++ b/libs/analytics/data-schemas/budget_headers.view.sql
@@ -1,0 +1,18 @@
+--TO BE UPDATED ONCE THE budget_headers collection is normalized
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(path_params, '$.budgetid') AS budget_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+
+  JSON_EXTRACT_SCALAR(data, '$.name') AS name,
+  CAST(JSON_EXTRACT(data, '$.startY') as INT64) AS start_year,
+  CAST(JSON_EXTRACT(data, '$.duration') as INT64) AS duration,
+  
+  JSON_EXTRACT(data, '$.headers') AS headers,
+  JSON_EXTRACT(data, '$.years') AS years,
+  
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_budget_headers_raw_latest`

--- a/libs/analytics/data-schemas/budget_lines.view.sql
+++ b/libs/analytics/data-schemas/budget_lines.view.sql
@@ -5,13 +5,16 @@ SELECT
   CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
   CAST(JSON_EXTRACT(data, '$.baseAmount') as FLOAT64) AS base_amount,
   CAST(JSON_EXTRACT(data, '$.isOccurenceStart') as BOOL) AS is_occurrence_start,
-  JSON_EXTRACT_SCALAR(data, '$.occurenceId') AS occurrence_id,
+  
 
-  JSON_EXTRACT_SCALAR(data, '$.plan.id') AS plan_id,
-  JSON_EXTRACT_SCALAR(data, '$.plan.lineId') AS line_id,
-  JSON_EXTRACT_SCALAR(data, '$.plan.budgetId') AS budget_id,
+  JSON_EXTRACT_SCALAR(data, '$.planId') AS plan_id,
+  JSON_EXTRACT_SCALAR(data, '$.lineId') AS line_id,
+  JSON_EXTRACT_SCALAR(data, '$.budgetId') AS budget_id,
 
   CAST(JSON_EXTRACT(data, '$.units') as INT64) AS units,
+
+  CAST(JSON_EXTRACT(data, '$.month') as INT64) AS month,
+  CAST(JSON_EXTRACT(data, '$.year') as INT64) AS year,
 
   JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
 

--- a/libs/analytics/data-schemas/budget_lines.view.sql
+++ b/libs/analytics/data-schemas/budget_lines.view.sql
@@ -4,6 +4,7 @@ SELECT
 
   CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
   CAST(JSON_EXTRACT(data, '$.baseAmount') as FLOAT64) AS base_amount,
+  JSON_EXTRACT_SCALAR(data, '$.allocatedTo') AS allocated_to,
   CAST(JSON_EXTRACT(data, '$.isOccurenceStart') as BOOL) AS is_occurrence_start,
   
 

--- a/libs/analytics/data-schemas/budget_lines.view.sql
+++ b/libs/analytics/data-schemas/budget_lines.view.sql
@@ -1,0 +1,20 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+
+  CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
+  CAST(JSON_EXTRACT(data, '$.baseAmount') as FLOAT64) AS base_amount,
+  CAST(JSON_EXTRACT(data, '$.isOccurenceStart') as BOOL) AS is_occurrence_start,
+  JSON_EXTRACT_SCALAR(data, '$.occurenceId') AS occurrence_id,
+
+  JSON_EXTRACT_SCALAR(data, '$.plan.id') AS plan_id,
+  JSON_EXTRACT_SCALAR(data, '$.plan.lineId') AS line_id,
+  JSON_EXTRACT_SCALAR(data, '$.plan.budgetId') AS budget_id,
+
+  CAST(JSON_EXTRACT(data, '$.units') as INT64) AS units,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_budget_lines_raw_latest`

--- a/libs/analytics/data-schemas/budget_plans.view.sql
+++ b/libs/analytics/data-schemas/budget_plans.view.sql
@@ -1,0 +1,38 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+
+  JSON_EXTRACT_SCALAR(data, '$.budgetId') AS budget_id,
+
+  CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
+  CAST(JSON_EXTRACT(data, '$.frequency') as INT64) AS frequency,
+  CAST(JSON_EXTRACT(data, '$.hasIncrease') as BOOL) AS has_increase,
+  CAST(JSON_EXTRACT(data, '$.king') as BOOL) AS king,
+
+  JSON_EXTRACT_SCALAR(data, '$.lineId') AS line_id,
+  JSON_EXTRACT_SCALAR(data, '$.lineName') AS line_name,
+
+  CAST(JSON_EXTRACT(data, '$.mode') as INT64) AS mode,
+  JSON_EXTRACT_SCALAR(data, '$.trCatId') AS transaction_category_id,
+  JSON_EXTRACT_SCALAR(data, '$.trTypeId') AS transaction_type_id,
+
+  CAST(JSON_EXTRACT(data, '$.units') as INT64) AS units,
+  CAST(JSON_EXTRACT(data, '$.xTimesInterval') as INT64) AS x_times_interval,
+
+  CAST(JSON_EXTRACT(data, '$.amntIncrConfig.incrFreq') as INT64) AS amnt_incr_freq,
+  CAST(JSON_EXTRACT(data, '$.amntIncrConfig.incrRate') as INT64) AS amnt_incr_rate,
+  JSON_EXTRACT_SCALAR(data, '$.amntIncrConfig.incrStyle') AS amnt_incr_style,
+  CAST(JSON_EXTRACT(data, '$.amntIncrConfig.interval') as INT64) AS unit_incr_interval,
+
+  CAST(JSON_EXTRACT(data, '$.unitIncrConfig.incrFreq') as INT64) AS unit_incr_freq,
+  CAST(JSON_EXTRACT(data, '$.unitIncrConfig.incrRate') as INT64) AS unit_incr_rate,
+  JSON_EXTRACT_SCALAR(data, '$.unitIncrConfig.incrStyle') AS unit_incr_style,
+  CAST(JSON_EXTRACT(data, '$.unitIncrConfig.interval') as INT64) AS unit_incr_interval,
+
+  JSON_EXTRACT_SCALAR(data, '$.fromMonth.slug') AS from_month,
+  CAST(JSON_EXTRACT(data, '$.fromYear') as INT64) AS from_year,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_budget_plans_raw_latest`

--- a/libs/analytics/data-schemas/budgets.view.sql
+++ b/libs/analytics/data-schemas/budgets.view.sql
@@ -1,0 +1,25 @@
+-- TO BE UPDATED ONCE THE "budgets" COLLECTION HAS BEEN NORMALIZED
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  JSON_EXTRACT_SCALAR(data, '$.name') AS name,
+
+  CAST(JSON_EXTRACT(data, '$.duration') as INT64) AS duration,
+  CAST(JSON_EXTRACT(data, '$.startMonth') as INT64) AS start_month,
+  CAST(JSON_EXTRACT(data, '$.startYear') as INT64) AS start_year,
+  CAST(JSON_EXTRACT(data, '$.status') as INT64) AS status,
+
+  children AS child,
+  amounts AS amount,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
+
+FROM `project-kujali.kdev.kdev_budgets_raw_latest`,
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.childrenList')) AS children
+JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.result.amountsYear')) AS amounts
+
+
+

--- a/libs/analytics/data-schemas/budgets.view.sql
+++ b/libs/analytics/data-schemas/budgets.view.sql
@@ -10,7 +10,7 @@ SELECT
   CAST(JSON_EXTRACT(data, '$.status') as INT64) AS status,
 
   children AS child,
-  amounts AS amount,
+  amounts_in_year AS amount_in_year,
 
   JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
 
@@ -19,7 +19,7 @@ SELECT
 
 FROM `project-kujali.kdev.kdev_budgets_raw_latest`,
 UNNEST(JSON_EXTRACT_ARRAY(data, '$.childrenList')) AS children
-JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.result.amountsYear')) AS amounts
+JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.result.amountsYear')) AS amounts_in_year
 
 
 

--- a/libs/analytics/data-schemas/business_tags.view.sql
+++ b/libs/analytics/data-schemas/business_tags.view.sql
@@ -1,0 +1,10 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+
+  JSON_EXTRACT_SCALAR(data, '$.label') AS label,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(cast(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_business_tags_raw_latest`

--- a/libs/analytics/data-schemas/companies.view.sql
+++ b/libs/analytics/data-schemas/companies.view.sql
@@ -1,0 +1,12 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.name') AS name,
+  JSON_EXTRACT_SCALAR(data, '$.hq') AS headquarters,
+  JSON_EXTRACT_SCALAR(data, '$.logoImgUrl') as logo_img_url,
+  JSON_EXTRACT_SCALAR(tags) AS tag,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_companies_raw_latest`,
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.tags')) AS tags

--- a/libs/analytics/data-schemas/config.view.sql
+++ b/libs/analytics/data-schemas/config.view.sql
@@ -1,0 +1,11 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+
+  CAST(JSON_EXTRACT(data, '$.number') as INT64) AS number,
+  JSON_EXTRACT_SCALAR(data, '$.prefix') AS prefix,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
+
+FROM `project-kujali.kdev.kdev_config_raw_latest`

--- a/libs/analytics/data-schemas/contact_roles.view.sql
+++ b/libs/analytics/data-schemas/contact_roles.view.sql
@@ -1,0 +1,10 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+
+  JSON_EXTRACT_SCALAR(data, '$.label') AS label,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_contact_roles_raw_latest`

--- a/libs/analytics/data-schemas/contacts.view.sql
+++ b/libs/analytics/data-schemas/contacts.view.sql
@@ -20,5 +20,5 @@ SELECT
   TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
 
 FROM `project-kujali.kdev.kdev_contacts_raw_latest`,
-UNNEST(JSON_EXTRACT_ARRAY(data, '$.role')) AS roles WITH SAFE_OFFSET
-JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.tags')) AS tags WITH SAFE_OFFSET USING(SAFE_OFFSET)
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.role')) AS roles WITH OFFSET
+CROSS JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.tags')) AS tags WITH OFFSET USING(OFFSET)

--- a/libs/analytics/data-schemas/contacts.view.sql
+++ b/libs/analytics/data-schemas/contacts.view.sql
@@ -21,4 +21,4 @@ SELECT
 
 FROM `project-kujali.kdev.kdev_contacts_raw_latest`,
 UNNEST(JSON_EXTRACT_ARRAY(data, '$.role')) AS roles WITH OFFSET
-CROSS JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.tags')) AS tags WITH OFFSET USING(OFFSET)
+JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.tags')) AS tags WITH OFFSET USING(OFFSET)

--- a/libs/analytics/data-schemas/contacts.view.sql
+++ b/libs/analytics/data-schemas/contacts.view.sql
@@ -1,0 +1,24 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.fName') AS firstname,
+  JSON_EXTRACT_SCALAR(data, '$.lName') AS lastname,
+  JSON_EXTRACT_SCALAR(data, '$.email') AS email,
+  JSON_EXTRACT_SCALAR(data, '$.dob') AS date_of_birth,
+  JSON_EXTRACT_SCALAR(data, '$.gender') AS gender,
+
+  JSON_EXTRACT_SCALAR(data, '$.phone') AS phone,
+  JSON_EXTRACT_SCALAR(data, '$.address') AS address,
+  JSON_EXTRACT_SCALAR(data, '$.facebook') AS facebook,
+  JSON_EXTRACT_SCALAR(data, '$.linkedin') AS linkedin,
+  JSON_EXTRACT_SCALAR(data, '$.company') AS company,
+  JSON_EXTRACT_SCALAR(data, '$.mainLanguage') AS main_language,
+
+  JSON_EXTRACT_SCALAR(roles) AS role,
+  JSON_EXTRACT_SCALAR(tags) AS tag,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_contacts_raw_latest`,
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.role')) AS roles WITH SAFE_OFFSET
+JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.tags')) AS tags WITH SAFE_OFFSET USING(SAFE_OFFSET)

--- a/libs/analytics/data-schemas/expenses.view.sql
+++ b/libs/analytics/data-schemas/expenses.view.sql
@@ -1,0 +1,21 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+
+  CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
+  CAST(JSON_EXTRACT(data, '$.baseAmount') as FLOAT64) AS base_amount,
+
+  CAST(JSON_EXTRACT_SCALAR(path_params, '$.year') as INT64) AS year,
+
+  CAST(JSON_EXTRACT(data, '$.isOccurenceStart') as BOOL) AS is_occurrence_start,
+  JSON_EXTRACT_SCALAR(data, '$.occurenceId') AS occurrence_id, 
+  JSON_EXTRACT_SCALAR(data, '$.plan.id') AS plan_id,
+  JSON_EXTRACT_SCALAR(data, '$.plan.lineId') AS line_id,
+  JSON_EXTRACT_SCALAR(data, '$.plan.budgetId') AS budget_id,
+
+  CAST(JSON_EXTRACT(data, '$.units') as INT64) AS units,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(cast(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_expenses_raw_latest`

--- a/libs/analytics/data-schemas/expenses.view.sql
+++ b/libs/analytics/data-schemas/expenses.view.sql
@@ -1,10 +1,10 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
-
+  
   CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
   CAST(JSON_EXTRACT(data, '$.baseAmount') as FLOAT64) AS base_amount,
 
+  CAST(JSON_EXTRACT_SCALAR(data, '$.id') as INT64) AS month,
   CAST(JSON_EXTRACT_SCALAR(path_params, '$.year') as INT64) AS year,
 
   CAST(JSON_EXTRACT(data, '$.isOccurenceStart') as BOOL) AS is_occurrence_start,

--- a/libs/analytics/data-schemas/invoices.view.sql
+++ b/libs/analytics/data-schemas/invoices.view.sql
@@ -1,0 +1,28 @@
+SELECT
+  JSON_EXTRACT(data, '$.id') AS id,
+
+  JSON_EXTRACT_SCALAR(data, '$.number') AS number,
+  JSON_EXTRACT_SCALAR(data, '$.title') AS title,
+  JSON_EXTRACT_SCALAR(data, '$.status') AS status,
+  JSON_EXTRACT_SCALAR(data, '$.structuredMessage') AS structured_message,
+  JSON_EXTRACT_SCALAR(data, '$.currency') AS currency,
+  JSON_EXTRACT_SCALAR(data, '$.customer') AS customer,
+  JSON_EXTRACT_SCALAR(data, '$.contact') AS contact,
+  JSON_EXTRACT_SCALAR(data, '$.company') AS company,
+  
+  CAST(JSON_EXTRACT(products, '$.cost') as INT64) AS product_cost,
+  JSON_EXTRACT_SCALAR(products, '$.desc') AS product_desc,
+  CAST(JSON_EXTRACT(products, '$.qty') as INT64) AS product_quantity,
+  CAST(JSON_EXTRACT(products, '$.vat') as INT64) AS product_vat,
+  JSON_EXTRACT_ARRAY(products, '$.discount') AS discount,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.date._seconds') as INT64)) AS date,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.dueDate._seconds') as INT64)) AS due_date,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_invoices_raw_latest`,
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.products')) AS products
+
+

--- a/libs/analytics/data-schemas/invoices_allocs.view.sql
+++ b/libs/analytics/data-schemas/invoices_allocs.view.sql
@@ -1,0 +1,31 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  JSON_EXTRACT_SCALAR(data, '$.notes') AS notes,
+  CAST(JSON_EXTRACT(data, '$.amount') as INT64) AS amount,
+
+  JSON_EXTRACT_SCALAR(data, '$.to') AS to_name,
+  JSON_EXTRACT_SCALAR(data, '$.from') AS from_name,
+  JSON_EXTRACT_SCALAR(data, '$.toAccName') AS to_account_name,
+  JSON_EXTRACT_SCALAR(data, '$.fromAccName') AS from_account_name,
+
+  JSON_EXTRACT_SCALAR(data, '$.allocId') AS allocation_id,
+  CAST(JSON_EXTRACT(data, '$.allocStatus') as INT64) AS allocation_status,
+
+  JSON_EXTRACT_SCALAR(elements, '$.accId') AS account_id,
+  JSON_EXTRACT_SCALAR(elements, '$.accName') AS account_name,
+  JSON_EXTRACT_SCALAR(elements, '$.invId') AS invoice_id,
+  JSON_EXTRACT_SCALAR(elements, '$.pId') AS payment_id,
+  CAST(JSON_EXTRACT(elements, '$.allocAmount') as INT64) AS allocation_amount,
+  CAST(JSON_EXTRACT(elements, '$.allocMode') as INT64) AS allocation_mode,
+  CAST(JSON_EXTRACT(elements, '$.allocType') as INT64) AS allocation_type,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.date._seconds') as INT64)) AS date,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_invoices_allocs_raw_latest`,
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.elements')) AS elements

--- a/libs/analytics/data-schemas/payments_allocs.view.sql
+++ b/libs/analytics/data-schemas/payments_allocs.view.sql
@@ -1,0 +1,20 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+
+  CAST(JSON_EXTRACT(data, '$.credit') as FLOAT64) AS credit,
+  CAST(JSON_EXTRACT(data, '$.allocStatus') as INT64) AS allocation_status,
+
+  JSON_EXTRACT_SCALAR(elements, '$.accId') AS account_id,
+  JSON_EXTRACT_SCALAR(elements, '$.accName') AS account_name,
+  CAST(JSON_EXTRACT(elements, '$.allocAmount') as FLOAT64) AS allocation_amount,
+  CAST(JSON_EXTRACT(elements, '$.allocMode') as INT64) AS allocation_mode,
+  JSON_EXTRACT_SCALAR(elements, '$.invoiceId') AS invoice_id,
+  JSON_EXTRACT_SCALAR(elements, '$.invoiceTitle') AS invoice_title,
+  JSON_EXTRACT_SCALAR(elements, '$.pId') AS payment_id,
+
+  JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+
+FROM `project-kujali.kdev.kdev_payments_allocs_raw_latest`,
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.elements')) AS elements

--- a/libs/analytics/data-schemas/ponto_transactions.view.sql
+++ b/libs/analytics/data-schemas/ponto_transactions.view.sql
@@ -1,0 +1,27 @@
+SELECT
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  JSON_EXTRACT_SCALAR(data, '$.description') AS description,
+  CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
+
+  JSON_EXTRACT_SCALAR(data, '$.to') AS to_name,
+  JSON_EXTRACT_SCALAR(data, '$.from') AS from_name,
+  JSON_EXTRACT_SCALAR(data, '$.toAccName') AS to_account_name,
+  JSON_EXTRACT_SCALAR(data, '$.fromAccName') AS from_account_name,
+  JSON_EXTRACT_SCALAR(data, '$.ibanTo') AS iban_to,
+  JSON_EXTRACT_SCALAR(data, '$.ibanFrom') AS iban_from,
+
+  CAST(JSON_EXTRACT(data, '$.mode') as INT64) AS mode,
+  JSON_EXTRACT_SCALAR(data, '$.notes') AS notes,
+  CAST(JSON_EXTRACT(data, '$.source') as INT64) AS source,
+  JSON_EXTRACT_SCALAR(data, '$.trStatus') AS transaction_status,
+  CAST(JSON_EXTRACT(data, '$.type') as INT64) AS type,
+
+  CAST(JSON_EXTRACT(data, '$.verified') as BOOL) AS verified,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.verificationDate._seconds') as INT64)) AS verification_date,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.date._seconds') as INT64)) AS date,
+
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+  TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
+
+FROM `project-kujali.kdev.kdev_ponto_transactions_raw_latest`,


### PR DESCRIPTION
# Description
This pull request adds the SQL statements used in creating the views that involve data streamed from Firestore collections, in the Bigquery console.

To achieve this:
- Data from Firestore collections were streamed to BigQuery via the "Stream Firestore to Bigquery" extension.
- Views were created via SQL statements involving streamed data in JSON format.

Fixes #40 
### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.