### PR TITLE
📈 Update BigQuery views' SQL statements #40

### DIFF
--- a/libs/analytics/data-schemas/accounts.view.sql
+++ b/libs/analytics/data-schemas/accounts.view.sql
@@ -1,7 +1,7 @@
 
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   JSON_EXTRACT_SCALAR(data, '$.accountHolder') AS holder_name,
   JSON_EXTRACT_SCALAR(data, '$.accountHolderEmail') AS holder_email,

--- a/libs/analytics/data-schemas/allocs.view.sql
+++ b/libs/analytics/data-schemas/allocs.view.sql
@@ -1,7 +1,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  document_id AS id,
   
-  CAST(JSON_EXTRACT( data , '$.amount') as FLOAT64) AS amount,
+  CAST(JSON_EXTRACT(data , '$.amount') as FLOAT64) AS amount,
 
   JSON_EXTRACT_SCALAR(data, '$.invId') AS invoice_id,
   JSON_EXTRACT_SCALAR(data, '$.pId') AS payment_id,

--- a/libs/analytics/data-schemas/bank_connections.view.sql
+++ b/libs/analytics/data-schemas/bank_connections.view.sql
@@ -1,6 +1,6 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
   JSON_EXTRACT_SCALAR(data, '$.name') AS name,
 
   JSON_EXTRACT_SCALAR(data, '$.paymentsActivationUrl') AS payments_activation_url,

--- a/libs/analytics/data-schemas/bank_connections_access_info.view.sql
+++ b/libs/analytics/data-schemas/bank_connections_access_info.view.sql
@@ -2,7 +2,7 @@ SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
   JSON_EXTRACT_SCALAR(path_params, '$.connectionid') AS connection_id,
 
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
   CAST(JSON_EXTRACT(data , '$.status') as INT64) AS status,
   
   JSON_EXTRACT_SCALAR(data, '$.userAccess.access_token') AS access_token,

--- a/libs/analytics/data-schemas/budget_config.view.sql
+++ b/libs/analytics/data-schemas/budget_config.view.sql
@@ -2,7 +2,7 @@ SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
   JSON_EXTRACT_SCALAR(path_params, '$.budgetid') AS budget_id,
 
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
   CAST(JSON_EXTRACT(data, '$.isbudgetLocked') as BOOL) AS is_budget_locked,
   JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
 

--- a/libs/analytics/data-schemas/budget_headers.view.sql
+++ b/libs/analytics/data-schemas/budget_headers.view.sql
@@ -2,7 +2,7 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
   JSON_EXTRACT_SCALAR(path_params, '$.budgetid') AS budget_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   JSON_EXTRACT_SCALAR(data, '$.name') AS name,
   CAST(JSON_EXTRACT(data, '$.startY') as INT64) AS start_year,

--- a/libs/analytics/data-schemas/budget_lines.view.sql
+++ b/libs/analytics/data-schemas/budget_lines.view.sql
@@ -1,6 +1,6 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
   CAST(JSON_EXTRACT(data, '$.baseAmount') as FLOAT64) AS base_amount,

--- a/libs/analytics/data-schemas/budget_plans.view.sql
+++ b/libs/analytics/data-schemas/budget_plans.view.sql
@@ -1,6 +1,6 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   JSON_EXTRACT_SCALAR(data, '$.budgetId') AS budget_id,
 

--- a/libs/analytics/data-schemas/budgets.view.sql
+++ b/libs/analytics/data-schemas/budgets.view.sql
@@ -1,7 +1,7 @@
 -- TO BE UPDATED ONCE THE "budgets" COLLECTION HAS BEEN NORMALIZED
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
   JSON_EXTRACT_SCALAR(data, '$.name') AS name,
 
   CAST(JSON_EXTRACT(data, '$.duration') as INT64) AS duration,
@@ -18,8 +18,8 @@ SELECT
   TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
 
 FROM `project-kujali.kdev.kdev_budgets_raw_latest`,
-UNNEST(JSON_EXTRACT_ARRAY(data, '$.childrenList')) AS children
-JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.result.amountsYear')) AS amounts_in_year
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.childrenList')) AS children WITH OFFSET
+JOIN UNNEST(JSON_EXTRACT_ARRAY(data, '$.result.amountsYear')) AS amounts_in_year WITH OFFSET USING(OFFSET)
 
 
 

--- a/libs/analytics/data-schemas/business_tags.view.sql
+++ b/libs/analytics/data-schemas/business_tags.view.sql
@@ -1,6 +1,6 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   JSON_EXTRACT_SCALAR(data, '$.label') AS label,
 

--- a/libs/analytics/data-schemas/companies.view.sql
+++ b/libs/analytics/data-schemas/companies.view.sql
@@ -1,5 +1,7 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  document_id AS id,
+
   JSON_EXTRACT_SCALAR(data, '$.name') AS name,
   JSON_EXTRACT_SCALAR(data, '$.hq') AS headquarters,
   JSON_EXTRACT_SCALAR(data, '$.logoImgUrl') as logo_img_url,

--- a/libs/analytics/data-schemas/config.view.sql
+++ b/libs/analytics/data-schemas/config.view.sql
@@ -1,6 +1,6 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   CAST(JSON_EXTRACT(data, '$.number') as INT64) AS number,
   JSON_EXTRACT_SCALAR(data, '$.prefix') AS prefix,

--- a/libs/analytics/data-schemas/contact_roles.view.sql
+++ b/libs/analytics/data-schemas/contact_roles.view.sql
@@ -1,6 +1,6 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   JSON_EXTRACT_SCALAR(data, '$.label') AS label,
 

--- a/libs/analytics/data-schemas/contacts.view.sql
+++ b/libs/analytics/data-schemas/contacts.view.sql
@@ -1,5 +1,7 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  document_id AS id,
+
   JSON_EXTRACT_SCALAR(data, '$.fName') AS firstname,
   JSON_EXTRACT_SCALAR(data, '$.lName') AS lastname,
   JSON_EXTRACT_SCALAR(data, '$.email') AS email,

--- a/libs/analytics/data-schemas/expenses.view.sql
+++ b/libs/analytics/data-schemas/expenses.view.sql
@@ -1,21 +1,25 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  document_id AS id,
   
   CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
-  CAST(JSON_EXTRACT(data, '$.baseAmount') as FLOAT64) AS base_amount,
+  JSON_EXTRACT_SCALAR(data, '$.allocatedTo') AS allocated_to,
 
-  CAST(JSON_EXTRACT_SCALAR(data, '$.id') as INT64) AS month,
-  CAST(JSON_EXTRACT_SCALAR(path_params, '$.year') as INT64) AS year,
+  JSON_EXTRACT_SCALAR(data, '$.note') AS note,
 
-  CAST(JSON_EXTRACT(data, '$.isOccurenceStart') as BOOL) AS is_occurrence_start,
-  JSON_EXTRACT_SCALAR(data, '$.occurenceId') AS occurrence_id, 
-  JSON_EXTRACT_SCALAR(data, '$.plan.id') AS plan_id,
-  JSON_EXTRACT_SCALAR(data, '$.plan.lineId') AS line_id,
-  JSON_EXTRACT_SCALAR(data, '$.plan.budgetId') AS budget_id,
+  JSON_EXTRACT_SCALAR(data, '$.planId') AS plan_id,
+  JSON_EXTRACT_SCALAR(data, '$.lineId') AS line_id,
+  JSON_EXTRACT_SCALAR(data, '$.budgetId') AS budget_id,
 
-  CAST(JSON_EXTRACT(data, '$.units') as INT64) AS units,
+  JSON_EXTRACT_SCALAR(data, '$.trCat') AS transaction_category,
+  JSON_EXTRACT_SCALAR(data, '$.trType') AS transaction_type,
+
+  CAST(JSON_EXTRACT(data, '$.vat') as INT64) AS vat,
+
+  TIMESTAMP_SECONDS(cast(JSON_EXTRACT(data, '$.date._seconds') as INT64)) AS date,
 
   JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
   TIMESTAMP_SECONDS(cast(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
+  TIMESTAMP_SECONDS(cast(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
 
 FROM `project-kujali.kdev.kdev_expenses_raw_latest`

--- a/libs/analytics/data-schemas/invoices.view.sql
+++ b/libs/analytics/data-schemas/invoices.view.sql
@@ -1,5 +1,6 @@
 SELECT
-  JSON_EXTRACT(data, '$.id') AS id,
+  JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
+  document_id AS id,
 
   JSON_EXTRACT_SCALAR(data, '$.number') AS number,
   JSON_EXTRACT_SCALAR(data, '$.title') AS title,
@@ -14,7 +15,7 @@ SELECT
   JSON_EXTRACT_SCALAR(products, '$.desc') AS product_desc,
   CAST(JSON_EXTRACT(products, '$.qty') as INT64) AS product_quantity,
   CAST(JSON_EXTRACT(products, '$.vat') as INT64) AS product_vat,
-  JSON_EXTRACT_ARRAY(products, '$.discount') AS discount,
+  discounts AS discount,
 
   JSON_EXTRACT_SCALAR(data, '$.createdBy') AS created_by,
 
@@ -24,5 +25,4 @@ SELECT
 
 FROM `project-kujali.kdev.kdev_invoices_raw_latest`,
 UNNEST(JSON_EXTRACT_ARRAY(data, '$.products')) AS products
-
-
+JOIN UNNEST(JSON_EXTRACT_ARRAY(products, '$.discount')) AS discounts

--- a/libs/analytics/data-schemas/invoices_allocs.view.sql
+++ b/libs/analytics/data-schemas/invoices_allocs.view.sql
@@ -1,7 +1,7 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
+  
   JSON_EXTRACT_SCALAR(data, '$.notes') AS notes,
   CAST(JSON_EXTRACT(data, '$.amount') as INT64) AS amount,
 

--- a/libs/analytics/data-schemas/payments.view.sql
+++ b/libs/analytics/data-schemas/payments.view.sql
@@ -1,8 +1,7 @@
 
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  -- String type
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   -- Datetime type
   TIMESTAMP_SECONDS(cast(JSON_EXTRACT( data , '$.date._seconds') as int64)) AS date,
@@ -10,6 +9,7 @@ SELECT
   -- Float type (decimal numbers)
   CAST(JSON_EXTRACT( data , '$.amount') as FLOAT64) AS amount,
 
+  -- String type
   JSON_EXTRACT_SCALAR(data, '$.notes') AS notes,
   JSON_EXTRACT_SCALAR(data, '$.description') AS descr,
   JSON_EXTRACT_SCALAR(data, '$.from') AS from_id,
@@ -22,11 +22,18 @@ SELECT
   JSON_EXTRACT_SCALAR(data, '$.source') AS tr_source,
   JSON_EXTRACT_SCALAR(data, '$.trStatus') AS transaction_status,
 
+  for_list AS for_text,
+
   -- Integer type
   CAST(JSON_EXTRACT( data , '$.mode') as INT64) AS mode,
   CAST(JSON_EXTRACT( data , '$.type') as INT64) AS type,
 
+  CAST(JSON_EXTRACT(data, '$.verified') as BOOL) as verified,
+
+  TIMESTAMP_SECONDS(cast(JSON_EXTRACT(data, '$.verificationDate._seconds') as INT64)) AS verification_date,
+
   TIMESTAMP_SECONDS(cast(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
   TIMESTAMP_SECONDS(cast(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
 
-FROM `project-kujali.kdev.kdev_raw_latest`
+FROM `project-kujali.kdev.kdev_payments_raw_latest`,
+UNNEST(JSON_EXTRACT_ARRAY(data, '$.for')) AS for_list

--- a/libs/analytics/data-schemas/payments_allocs.view.sql
+++ b/libs/analytics/data-schemas/payments_allocs.view.sql
@@ -1,6 +1,6 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
 
   CAST(JSON_EXTRACT(data, '$.credit') as FLOAT64) AS credit,
   CAST(JSON_EXTRACT(data, '$.allocStatus') as INT64) AS allocation_status,

--- a/libs/analytics/data-schemas/ponto_transactions.view.sql
+++ b/libs/analytics/data-schemas/ponto_transactions.view.sql
@@ -1,6 +1,6 @@
 SELECT
   JSON_EXTRACT_SCALAR(path_params, '$.orgid') AS org_id,
-  JSON_EXTRACT_SCALAR(data, '$.id') AS id,
+  document_id AS id,
   JSON_EXTRACT_SCALAR(data, '$.description') AS description,
   CAST(JSON_EXTRACT(data, '$.amount') as FLOAT64) AS amount,
 
@@ -24,4 +24,4 @@ SELECT
   TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.createdOn._seconds') as INT64)) AS created_on,
   TIMESTAMP_SECONDS(CAST(JSON_EXTRACT(data, '$.updatedOn._seconds') as INT64)) AS updated_on,
 
-FROM `project-kujali.kdev.kdev_ponto_transactions_raw_latest`,
+FROM `project-kujali.kdev.kdev_ponto_transactions_raw_latest`


### PR DESCRIPTION
# Description
This pull request updates the SQL statements used in creating the views that involve data streamed from Firestore collections, in the Bigquery console. All the updated views have an id to allow for analysis and visualization of the data.

To achieve this:
- From the SQL statements used to create the views, the id was selected via "document_id" rather than "data".

Fixes #40 

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.