### PR TITLE
Feature: Add Note to Budget Command

### DIFF
--- a/libs/model/budgetting/budget-notes/src/lib/domain/add-note.command.ts
+++ b/libs/model/budgetting/budget-notes/src/lib/domain/add-note.command.ts
@@ -1,0 +1,8 @@
+export class AddNoteToBudgetCommand {
+  constructor(
+    public readonly budgetId: string,
+    public readonly content: string,
+    public readonly createdBy: string,
+    public readonly createdAt: Date = new Date()
+  ) {}
+}

--- a/libs/model/budgetting/budget-notes/src/lib/domain/add-note.handler.ts
+++ b/libs/model/budgetting/budget-notes/src/lib/domain/add-note.handler.ts
@@ -1,0 +1,23 @@
+import { AddNoteToBudgetCommand } from './add-note.command';
+
+export interface ICommandHandler<TCommand> {
+  execute(command: TCommand): Promise<void>;
+}
+
+export class AddNoteToBudgetHandler
+  implements ICommandHandler<AddNoteToBudgetCommand>
+{
+  constructor(private readonly repo: any) {}
+
+  async execute(command: AddNoteToBudgetCommand): Promise<void> {
+    if (!command.content?.trim()) {
+      throw new Error('Note content cannot be empty');
+    }
+
+    await this.repo.addNote(command.budgetId, {
+      content: command.content,
+      createdBy: command.createdBy,
+      createdAt: command.createdAt,
+    });
+  }
+}


### PR DESCRIPTION
Hi team,

This pull request contains my implementation for the “Add Note to Budget” command. 
I approached it as simply and clearly as I could based on the CQRS pattern used in the project.

What I built
- I created a new library under `libs/model/budgetting/budget-notes`
- I added a command (`AddNoteToBudgetCommand`) that holds the data needed to add a note
- I created a handler (`AddNoteToBudgetHandler`) that validates the note and then calls the repository to save it

How I understand the backend flow
From what I learned while reading through the repository:
- Commands are used to represent actions the system wants to perform
- Command handlers contain the business logic for those actions
- Repositories take care of saving or updating data

So in my case, the handler checks that the note content is not empty, and then it passes the data to the repository’s `addNote` function.

How I think this would be deployed
The project uses a serverless approach. I understand this to mean that my handler would run as a serverless function (e.g., Google Cloud Functions).  
The nice thing about serverless is that I don’t need to manage servers , the function only runs when it’s needed.

How serverless scales
Serverless functions scale automatically depending on traffic.  
If many users are adding notes at the same time, more instances will run.  
If nobody is using the feature, it scales back down.  
This makes it efficient and cost-effective.

Thank you for reviewing my work.
