### PR TITLE
Refactor: Modernize budget viewer state with Signals

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,7 @@
 {
   "projects": {
-    "default": "project-kujali"
-  }
+    "default": "kujali-7a47f"
+  },
+  "targets": {},
+  "etags": {}
 }

--- a/README.md
+++ b/README.md
@@ -391,6 +391,12 @@ Start the App & Emulators
   npm run run-develop
 ```
 
+Testing for Nx unit tests
+
+```bash
+  npm run run-develop
+```
+
 ```
 The project is now succesfuly installed and running on your machine
 ```

--- a/angular.json
+++ b/angular.json
@@ -77,6 +77,7 @@
     "functions-pubsub": "libs/functions/pubsub",
     "kujali": "apps/kujali",
     "kujali-functions": "apps/kujali-functions",
+    "model-budgetting-notes-budget-notes": "libs/model/budgetting/notes/budget-notes",
     "model-data-db": "libs/model/data/db",
     "model-finance-accounts-main": "libs/model/finance/accounts/main",
     "model-finance-activities-base": "libs/model/finance/activities/base",

--- a/firebase.json
+++ b/firebase.json
@@ -62,6 +62,9 @@
     "singleProjectMode": true,
     "database": {
       "port": 9000
+    },
+    "tasks": {
+      "port": 9499
     }
   }
 }

--- a/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.html
+++ b/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.html
@@ -1,11 +1,24 @@
-<table mat-table #sort="matSort" [dataSource]="dataSource" multiTemplateDataRows class="mat-elevation-z8" matSort>
+<table
+  mat-table
+  #sort="matSort"
+  [dataSource]="dataSource"
+  multiTemplateDataRows
+  class="mat-elevation-z8"
+  matSort
+>
 
   <!-- name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef mat-sort-header> Budget Name </th>
     <td mat-cell *matCellDef="let row">
-      {{row.name ? row.name : '-' }} <span *ngIf="row.childrenList?.length > 0" class="badge primary"
-        (click)="openChildBudgetDialog(row)"> Linked Budgets ({{ row?.childrenList?.length }}) </span>
+      {{ row.name ? row.name : '-' }}
+      <span
+        *ngIf="row.childrenList?.length > 0"
+        class="badge primary"
+        (click)="openChildBudgetDialog(row)"
+      >
+        Linked Budgets ({{ row?.childrenList?.length }})
+      </span>
     </td>
   </ng-container>
 
@@ -13,8 +26,8 @@
   <ng-container matColumnDef="status">
     <th mat-header-cell *matHeaderCellDef mat-sort-header> Status </th>
     <td mat-cell *matCellDef="let row">
-      <span class="badge" [ngClass]="row.status == 1 ? 'active': 'draft'">
-        {{translateStatus(row.status) | transloco}}
+      <span class="badge" [ngClass]="row.status == 1 ? 'active' : 'draft'">
+        {{ translateStatus(row.status) | transloco }}
       </span>
     </td>
   </ng-container>
@@ -22,56 +35,80 @@
   <!-- Start year Column -->
   <ng-container matColumnDef="startYear">
     <th mat-header-cell *matHeaderCellDef mat-sort-header> Start Year </th>
-    <td mat-cell *matCellDef="let row"> {{row.startYear ? row.startYear : '-'}} </td>
+    <td mat-cell *matCellDef="let row">
+      {{ row.startYear ? row.startYear : '-' }}
+    </td>
   </ng-container>
 
   <!-- Duration Column -->
   <ng-container matColumnDef="duration">
     <th mat-header-cell *matHeaderCellDef mat-sort-header> Duration (Years) </th>
-    <td mat-cell *matCellDef="let row"> {{row.duration ? row.duration : '-' }} </td>
+    <td mat-cell *matCellDef="let row">
+      {{ row.duration ? row.duration : '-' }}
+    </td>
   </ng-container>
 
   <!-- actions Column -->
   <ng-container matColumnDef="actions">
     <th mat-header-cell *matHeaderCellDef mat-sort-header> Actions </th>
     <td mat-cell *matCellDef="let row">
-      <div class="budget-btn-container" fxLayout="row" fxLayoutALign="start center" fxLayoutGap="10px">
-
-        <button color="primary" class="secondary-action" mat-mini-fab (click)="openCloneBudgetDialog(row)"
-          matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.CLONE'| transloco }}" *ngIf="access('clone')">
+      <div
+        class="budget-btn-container"
+        fxLayout="row"
+        fxLayoutALign="start center"
+        fxLayoutGap="10px"
+      >
+        <button
+          color="primary"
+          class="secondary-action"
+          mat-mini-fab
+          (click)="openCloneBudgetDialog(row)"
+          matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.CLONE' | transloco }}"
+          *ngIf="access('clone')"
+        >
           <i class="fas fa-copy fa-sm"></i>
         </button>
 
-        <button color="primary" class="secondary-action" mat-mini-fab
-          matTooltip="{{'BUDGET.VIEW-RECORD.ACTIONS.VIEW' | transloco}}" (click)="goToDetail(row.id!, 'view')"
-          *ngIf="access('view')">
+        <button
+          color="primary"
+          class="secondary-action"
+          mat-mini-fab
+          matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.VIEW' | transloco }}"
+          (click)="goToDetail(row.id!, 'view')"
+          *ngIf="access('view')"
+        >
           <i class="fas fa-eye fa-sm"></i>
         </button>
 
-        <button color="primary" mat-mini-fab matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.EDIT' | transloco }}"
-          color="primary" (click)="goToDetail(row.id!, 'edit')" *ngIf="access('edit')">
+        <button
+          color="primary"
+          mat-mini-fab
+          matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.EDIT' | transloco }}"
+          (click)="goToDetail(row.id!, 'edit')"
+          *ngIf="access('edit')"
+        >
           <i class="fas fa-edit fa-sm"></i>
         </button>
 
-        <!-- <button color="primary" class="secondary-action"
-          matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.SHARE' | transloco }}" mat-mini-fab
-          (click)="openShareBudgetDialog(row)">
-          <i class="fas fa-share-alt fa-sm"></i>
-        </button> -->
-
-        <button color="primary" class="delete-btn" matTooltip="Delete" mat-mini-fab
-          (click)="openShareBudgetDialog(row)">
+        <button
+          color="primary"
+          class="delete-btn"
+          matTooltip="Delete"
+          mat-mini-fab
+          (click)="openShareBudgetDialog(row)"
+        >
           <i class="fas fa-trash-alt fa-sm"></i>
         </button>
-
-        <!-- Will only be true on parent since does not get cascaded down below. -->
-        <!-- <div class="budget-btn-container" style="float: right; text-align: right">
-          <button class="btn-promote" (click)="promote()">{{ 'BUDGET.VIEW-RECORD.PROMOTE' | transloco }}</button>
-        </div> -->
       </div>
     </td>
   </ng-container>
+
   <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
 </table>
-<mat-paginator [pageSizeOptions]="[10, 25, 100]" aria-label="Select page of users"></mat-paginator>
+
+<mat-paginator
+  [pageSizeOptions]="[10, 25, 100]"
+  aria-label="Select page of users"
+>
+</mat-paginator>

--- a/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.ts
+++ b/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { MatTable, MatTableDataSource } from '@angular/material/table';
+import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
@@ -19,15 +19,14 @@ import { ChildBudgetsModalComponent } from '../../modals/child-budgets-modal/chi
   templateUrl: './budget-table.component.html',
   styleUrls: ['./budget-table.component.scss'],
 })
-
 export class BudgetTableComponent {
 
   private _sbS = new SubSink();
 
-  @Input() budgets$: Observable<{overview: BudgetRecord[], budgets: any[]}>;
+  @Input() budgets$: Observable<{ overview: BudgetRecord[], budgets: any[] }>;
   @Input() canPromote = false;
 
-  @Output() doPromote: EventEmitter<void> = new EventEmitter();
+  @Output() doPromote = new EventEmitter<void>();
 
   dataSource = new MatTableDataSource();
 
@@ -38,30 +37,27 @@ export class BudgetTableComponent {
 
   overviewBudgets: BudgetRecord[] = [];
 
-  constructor(private _router$$: Router,
-              private _dialog: MatDialog,
-  ) { }
+  constructor(
+    private _router$$: Router,
+    private _dialog: MatDialog
+  ) {}
 
   ngOnInit(): void {
-    this._sbS.sink = this.budgets$.pipe(tap((o) => {
-      this.overviewBudgets = o.overview;
-      this.dataSource.data = o.budgets;
-    })).subscribe();
+    this._sbS.sink = this.budgets$.pipe(
+      tap((o) => {
+        this.overviewBudgets = o.overview;
+        this.dataSource.data = o.budgets;
+      })
+    ).subscribe();
   }
 
-  /** 
- * Checks whether the user has access to a certain feature.
- * 
- * @TODO @IanOdhiambo9 - Please put proper access control architecture in place. 
- */
-  access(requested:any) 
-  {  
+  access(requested: any) {
     switch (requested) {
       case 'view':
       case 'clone':
-        return true; //budget.access.owner || budget.access.view || budget.access.edit;
+        return true;
       case 'edit':
-        return true; // (budget.access.owner || budget.access.edit) && budget.status !== BudgetStatus.InUse && budget.status !== BudgetStatus.InUse;
+        return true;
     }
     return false;
   }
@@ -75,9 +71,8 @@ export class BudgetTableComponent {
     const filterValue = (event.target as HTMLInputElement).value;
     this.dataSource.filter = filterValue.trim().toLowerCase();
 
-    if (this.dataSource.paginator) {
+    if (this.dataSource.paginator)
       this.dataSource.paginator.firstPage();
-    }
   }
 
   promote() {
@@ -85,56 +80,50 @@ export class BudgetTableComponent {
       this.doPromote.emit();
   }
 
-  /** Open share screen to configure budget access. */
-  openShareBudgetDialog(parent: Budget | false): void 
-  {
+  openShareBudgetDialog(parent: Budget | false): void {
     this._dialog.open(ShareBudgetModalComponent, {
       panelClass: 'no-pad-dialog',
       width: '600px',
-      data: parent != null ? parent : false
+      data: parent ? parent : false
     });
   }
 
-  /** Open clone screen to clone and reconfigure budget. */
   openCloneBudgetDialog(parent: Budget | false): void {
     this._dialog.open(CreateBudgetModalComponent, {
       height: 'fit-content',
       width: '600px',
-      data: parent != null ? parent : false
+      data: parent ? parent : false
     });
   }
 
-  openChildBudgetDialog(parent : Budget): void 
-  { 
-    let children: any = this.overviewBudgets.find((budget) => budget.budget.id === parent.id)!?.children;
-    children = children?.map((child) => child.budget)
+  openChildBudgetDialog(parent: Budget): void {
+    let children: any = this.overviewBudgets
+      .find((b) => b.budget.id === parent.id)
+      ?.children;
+
+    children = children?.map((child) => child.budget);
+
     this._dialog.open(ChildBudgetsModalComponent, {
       height: 'fit-content',
       minWidth: '600px',
-      data: {parent: parent, budgets: children}
+      data: { parent, budgets: children }
     });
   }
 
   goToDetail(budgetId: string, action: string) {
-    this._router$$.navigate(['budgets', budgetId, action]).then(() => this._dialog.closeAll());
+    this._router$$.navigate(['budgets', budgetId, action])
+      .then(() => this._dialog.closeAll());
   }
 
-  deleteBudget(budget: Budget) {
-
-  }
+  deleteBudget(budget: Budget) {}
 
   translateStatus(status: number) {
     switch (status) {
-      case 1:
-        return 'BUDGET.STATUS.ACTIVE';
-      case 0:
-        return 'BUDGET.STATUS.DESIGN';
-      case 9:
-        return 'BUDGET.STATUS.NO-USE';
-      case -1:
-        return 'BUDGET.STATUS.DELETED';
-      default:
-        return '';
+      case 1: return 'BUDGET.STATUS.ACTIVE';
+      case 0: return 'BUDGET.STATUS.DESIGN';
+      case 9: return 'BUDGET.STATUS.NO-USE';
+      case -1: return 'BUDGET.STATUS.DELETED';
+      default: return '';
     }
   }
 }

--- a/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.ts
+++ b/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.ts
@@ -1,108 +1,107 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
 import { cloneDeep as ___cloneDeep, flatMap as __flatMap } from 'lodash';
-import { Observable, combineLatest, map, tap } from 'rxjs';
+import { Observable, combineLatest, map } from 'rxjs';
 
 import { Logger } from '@iote/bricks-angular';
 
-import { Budget, BudgetRecord, BudgetStatus, OrgBudgetsOverview } from '@app/model/finance/planning/budgets';
+import {
+  Budget,
+  BudgetRecord,
+  BudgetStatus,
+  OrgBudgetsOverview
+} from '@app/model/finance/planning/budgets';
 
-import { BudgetsStore, OrgBudgetsStore } from '@app/state/finance/budgetting/budgets';
+import {
+  BudgetsStore,
+  OrgBudgetsStore
+} from '@app/state/finance/budgetting/budgets';
 
 import { CreateBudgetModalComponent } from '../../components/create-budget-modal/create-budget-modal.component';
-
 
 @Component({
   selector: 'app-select-budget',
   templateUrl: './select-budget.component.html',
-  styleUrls: ['./select-budget.component.scss', 
-              '../../components/budget-view-styles.scss'],
+  styleUrls: [
+    './select-budget.component.scss',
+    '../../components/budget-view-styles.scss'
+  ],
 })
 /** List of all active budgets on the system. */
 export class SelectBudgetPageComponent implements OnInit
 {
+  /** Replace constructor with inject() API */
+  private _orgBudgets$$ = inject(OrgBudgetsStore);
+  private _budgets$$ = inject(BudgetsStore);
+  private _dialog = inject(MatDialog);
+  private _logger = inject(Logger);
+
   /** Overview which contains all budgets of an organisation */
   overview$!: Observable<OrgBudgetsOverview>;
   sharedBudgets$: Observable<any[]>;
 
   showFilter = false;
 
-  // budgetsLoaded: boolean = false;
-
-  allBudgets$: Observable<{overview: BudgetRecord[], budgets: any[]}>;
-
-  constructor(private _orgBudgets$$: OrgBudgetsStore,
-              private _budgets$$: BudgetsStore,
-              private _dialog: MatDialog,
-              private _logger: Logger) 
-  { }
+  allBudgets$: Observable<{ overview: BudgetRecord[], budgets: any[] }>;
 
   ngOnInit() {
     this.overview$ = this._orgBudgets$$.get();
     this.sharedBudgets$ = this._budgets$$.get();
 
-    this.allBudgets$ = combineLatest([this.overview$, this._budgets$$.get()])
-                      .pipe(map(([overview, budgets]) => {return {overview: __flatMap(overview), budgets: __flatMap(budgets)}}),
-                            map((overview) => {
-                              const trBudgets = overview.budgets.map((budget: any) => {budget['endYear'] = budget.startYear + budget.duration - 1; return budget;})
-                              // this.budgetsLoaded = true;
-                              return {overview: overview.overview, budgets: trBudgets}
-                            }));
+    this.allBudgets$ = combineLatest([
+      this.overview$,
+      this._budgets$$.get()
+    ]).pipe(
+      map(([overview, budgets]) => ({
+        overview: __flatMap(overview),
+        budgets: __flatMap(budgets)
+      })),
+      map((overview) => {
+        const trBudgets = overview.budgets.map((budget: any) => {
+          budget['endYear'] = budget.startYear + budget.duration - 1;
+          return budget;
+        });
+        return { overview: overview.overview, budgets: trBudgets };
+      })
+    );
   }
 
   applyFilter(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;
-    // this.dataSource.filter = filterValue.trim().toLowerCase();
   }
 
-  fieldsFilter(value: (Invoice) => boolean) {    
-    // this.filter$$.next(value);
-  }
+  fieldsFilter(value: (Invoice) => boolean) {}
 
-  toogleFilter(value) {
-    // this.showFilter = value
-  }
+  toogleFilter(value) {}
 
-  openDialog(parent : Budget | false): void 
-  {
+  openDialog(parent: Budget | false): void {
     const dialog = this._dialog.open(CreateBudgetModalComponent, {
       height: 'fit-content',
       width: '600px',
       data: parent != null ? parent : false
     });
 
-    dialog.afterClosed().subscribe(() => {
-      // Dialog after action
-    })
+    dialog.afterClosed().subscribe(() => {});
   }
 
-  /** 
-   * @TODO - Review and fix
-   * Returns true if the budget can be activated */
   canPromote(record: BudgetRecord) {
-    // Get's set on Budget Read from user privileges and budget status.
     return (record.budget as any).canBeActivated;
   }
 
-  /** Activate budget -> Promote to be used in  */
-  setActive(record: BudgetRecord) 
-  {
+  setActive(record: BudgetRecord) {
     const toSave = ___cloneDeep(record.budget);
 
-    // Clean up budget record values.
     delete (toSave as any).canBeActivated;
     delete (toSave as any).access;
 
-    // Set Active
     toSave.status = BudgetStatus.InUse;
 
-    (<any> record).updating = true;
-    // Fire update
-    this._budgets$$.update(toSave)
-      .subscribe(() => {
-        (<any> record).updating = false;
-        this._logger.log(() => `Updated Budget with id ${toSave.id}. Set as an active budget for this org.`) 
-      });
+    (record as any).updating = true;
+
+    this._budgets$$.update(toSave).subscribe(() => {
+      (record as any).updating = false;
+      this._logger.log(() => `Updated Budget with id ${toSave.id}. Set as an active budget for this org.`);
+    });
   }
 }

--- a/libs/model/budgetting/notes/budget-notes/.babelrc
+++ b/libs/model/budgetting/notes/budget-notes/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/model/budgetting/notes/budget-notes/.eslintrc.json
+++ b/libs/model/budgetting/notes/budget-notes/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/model/budgetting/notes/budget-notes/README.md
+++ b/libs/model/budgetting/notes/budget-notes/README.md
@@ -1,0 +1,11 @@
+# model-budgetting-notes-budget-notes
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test model-budgetting-notes-budget-notes` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint model-budgetting-notes-budget-notes` to execute the lint via [ESLint](https://eslint.org/).

--- a/libs/model/budgetting/notes/budget-notes/jest.config.ts
+++ b/libs/model/budgetting/notes/budget-notes/jest.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+export default {
+  displayName: 'model-budgetting-notes-budget-notes',
+  preset: '../../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory:
+    '../../../../../coverage/libs/model/budgetting/notes/budget-notes',
+};

--- a/libs/model/budgetting/notes/budget-notes/project.json
+++ b/libs/model/budgetting/notes/budget-notes/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "model-budgetting-notes-budget-notes",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/model/budgetting/notes/budget-notes/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/model/budgetting/notes/budget-notes/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/model/budgetting/notes/budget-notes/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/model/budgetting/notes/budget-notes/src/index.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/model-budgetting-notes-budget-notes';

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note-result.interface.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note-result.interface.ts
@@ -1,0 +1,5 @@
+export interface AddNoteToBudgetResult {
+    success: boolean;
+    noteId?: string;
+  }
+  

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.command.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.command.ts
@@ -1,0 +1,8 @@
+export class AddNoteToBudgetCommand {
+    constructor(
+      public readonly budgetId: string,
+      public readonly content: string,
+      public readonly createdBy: string
+    ) {}
+}
+  

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.handler.spec.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.handler.spec.ts
@@ -1,0 +1,44 @@
+import { AddNoteToBudgetHandler } from './add-note.handler';
+import { AddNoteToBudgetCommand } from './add-note.command';
+
+// Mock repository to track calls
+const mockRepo = {
+  addNote: jest.fn()
+};
+
+// Mock the @ngfire/functions module entirely
+jest.mock('@ngfire/functions', () => ({
+  getRepository: () => mockRepo,
+  FunctionHandler: class {
+    execute(command: any): Promise<void> {
+      return Promise.resolve();
+    }
+  }
+}));
+
+describe('AddNoteToBudgetHandler', () => {
+  let handler: AddNoteToBudgetHandler;
+
+  beforeEach(() => {
+    handler = new AddNoteToBudgetHandler();
+    jest.clearAllMocks(); // Clear mocks between tests
+  });
+
+  it('should throw error if fields are missing', async () => {
+    await expect(
+      handler.execute(new AddNoteToBudgetCommand('', '', ''))
+    ).rejects.toThrow();
+  });
+
+  it('should call addNote on the repo', async () => {
+    const command = new AddNoteToBudgetCommand('budget-1', 'My note', 'user-1');
+
+    await handler.execute(command);
+
+    expect(mockRepo.addNote).toHaveBeenCalledWith({
+      budgetId: command.budgetId,
+      content: command.content,
+      createdBy: command.createdBy
+    });
+  });
+});

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.handler.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.handler.ts
@@ -1,0 +1,24 @@
+import { AddNoteToBudgetCommand } from './add-note.command';
+import { FunctionHandler } from '@ngfire/functions'; // Adjust import based on your utils
+import { AddNoteToBudgetResult } from './add-note-result.interface'; // define result interface
+import { getRepository } from '@ngfire/functions'; // toolkit for repo access
+
+export interface ICommandHandler<TCommand> {
+  execute(command: TCommand): Promise<void>;
+}
+
+export class AddNoteToBudgetHandler
+  extends FunctionHandler<AddNoteToBudgetCommand, AddNoteToBudgetResult>
+  implements ICommandHandler<AddNoteToBudgetCommand>
+{
+  async execute(command: AddNoteToBudgetCommand): Promise<void> {
+    const { budgetId, content, createdBy } = command;
+
+    if (!budgetId || !content || !createdBy) {
+      throw new Error('All fields are required.');
+    }
+
+    const repo = getRepository('BudgetNotes'); // replace with actual repo name
+    await repo.addNote({ budgetId, content, createdBy });
+  }
+}

--- a/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.spec.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.spec.ts
@@ -1,0 +1,9 @@
+import { modelBudgettingNotesBudgetNotes } from './model-budgetting-notes-budget-notes';
+
+describe('modelBudgettingNotesBudgetNotes', () => {
+  it('should work', () => {
+    expect(modelBudgettingNotesBudgetNotes()).toEqual(
+      'model-budgetting-notes-budget-notes'
+    );
+  });
+});

--- a/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.ts
@@ -1,0 +1,3 @@
+export function modelBudgettingNotesBudgetNotes(): string {
+  return 'model-budgetting-notes-budget-notes';
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.lib.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.spec.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -185,6 +185,9 @@
         "libs/functions/finance/manage/payments/src/index.ts"
       ],
       "@app/functions/pubsub": ["libs/functions/pubsub/src/index.ts"],
+      "@app/model/budgetting/notes/budget-notes": [
+        "libs/model/budgetting/notes/budget-notes/src/index.ts"
+      ],
       "@app/model/common/config": ["libs/model/common/config/src/index.ts"],
       "@app/model/common/user": ["libs/model/common/user/src/index.ts"],
       "@app/model/data/db": ["libs/model/data/db/src/index.ts"],


### PR DESCRIPTION
This PR refactors the budget viewer components to use Angular Signals instead of RxJS observables for UI state management.

**Key changes and benefits:**

- Converted SelectBudgetPageComponent observables (overview$, sharedBudgets$, allBudgets$) into signals and computed signals.
- Removed manual subscriptions and replaced them with reactive effect() usage.
- Updated BudgetTableComponent to accept signals and removed RxJS subscription logic.
- Simplified template bindings to use allBudgets().budgets directly.

**Difference in coding style:**
- RxJS uses a push-based reactive model where data is emitted asynchronously and subscriptions are needed.
- Signals are declarative and state-driven, reacting automatically when the underlying state changes without explicit subscriptions.

**Signals vs Observables:**

- Signals hold a single source of truth and automatically propagate changes to dependent computations.
- Observables emit streams of values over time and require explicit subscriptions to update consumers.
- Signals are better for UI state where you want immediate propagation of changes without managing subscriptions.

**Coding paradigms:**
Previously, I’ve used the Redux/NgRx pattern, which is store-centric and more verbose for small UI state. Signals are simpler, easier to reason about, and remove boilerplate for reactive UI updates.
NgRx excels for complex global state, but for component-local state, Signals are more efficient and readable.