### PR TITLE
Refactor: Modernize budget viewer state with Signals

### DIFF
--- a/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.html
+++ b/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.html
@@ -1,77 +1,69 @@
-<table mat-table #sort="matSort" [dataSource]="dataSource" multiTemplateDataRows class="mat-elevation-z8" matSort>
+<ng-container *ngIf="budgets$ | async as data">
+  {{ (dataSource.data = data.budgets) || '' }}
+  {{ (overviewBudgets = data.overview) || '' }}
+</ng-container>
 
-  <!-- name Column -->
-  <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Budget Name </th>
-    <td mat-cell *matCellDef="let row">
-      {{row.name ? row.name : '-' }} <span *ngIf="row.childrenList?.length > 0" class="badge primary"
-        (click)="openChildBudgetDialog(row)"> Linked Budgets ({{ row?.childrenList?.length }}) </span>
-    </td>
-  </ng-container>
+<div class="table-wrapper">
+  <table mat-table #sort="matSort" [dataSource]="dataSource" multiTemplateDataRows class="mat-elevation-z8" matSort>
 
-  <!-- status Column -->
-  <ng-container matColumnDef="status">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Status </th>
-    <td mat-cell *matCellDef="let row">
-      <span class="badge" [ngClass]="row.status == 1 ? 'active': 'draft'">
-        {{translateStatus(row.status) | transloco}}
-      </span>
-    </td>
-  </ng-container>
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Budget Name </th>
+      <td mat-cell *matCellDef="let row">
+        {{row.name || '-'}}
+        <span *ngIf="row.childrenList?.length" class="badge primary" (click)="openChildBudgetDialog(row)">
+          Linked Budgets ({{ row.childrenList.length }})
+        </span>
+      </td>
+    </ng-container>
 
-  <!-- Start year Column -->
-  <ng-container matColumnDef="startYear">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Start Year </th>
-    <td mat-cell *matCellDef="let row"> {{row.startYear ? row.startYear : '-'}} </td>
-  </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Status </th>
+      <td mat-cell *matCellDef="let row">
+        <span class="badge" [ngClass]="row.status == 1 ? 'active' : 'draft'">
+          {{translateStatus(row.status) | transloco}}
+        </span>
+      </td>
+    </ng-container>
 
-  <!-- Duration Column -->
-  <ng-container matColumnDef="duration">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Duration (Years) </th>
-    <td mat-cell *matCellDef="let row"> {{row.duration ? row.duration : '-' }} </td>
-  </ng-container>
+    <ng-container matColumnDef="startYear">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Start Year </th>
+      <td mat-cell *matCellDef="let row"> {{row.startYear || '-'}} </td>
+    </ng-container>
 
-  <!-- actions Column -->
-  <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Actions </th>
-    <td mat-cell *matCellDef="let row">
-      <div class="budget-btn-container" fxLayout="row" fxLayoutALign="start center" fxLayoutGap="10px">
+    <ng-container matColumnDef="duration">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Duration (Years) </th>
+      <td mat-cell *matCellDef="let row"> {{row.duration || '-'}} </td>
+    </ng-container>
 
-        <button color="primary" class="secondary-action" mat-mini-fab (click)="openCloneBudgetDialog(row)"
-          matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.CLONE'| transloco }}" *ngIf="access('clone')">
-          <i class="fas fa-copy fa-sm"></i>
-        </button>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Actions </th>
+      <td mat-cell *matCellDef="let row">
+        <div class="budget-btn-container" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
+          <button mat-mini-fab color="primary" class="secondary-action" (click)="openCloneBudgetDialog(row)"
+            *ngIf="access('clone')" matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.CLONE' | transloco }}">
+            <i class="fas fa-copy fa-sm"></i>
+          </button>
 
-        <button color="primary" class="secondary-action" mat-mini-fab
-          matTooltip="{{'BUDGET.VIEW-RECORD.ACTIONS.VIEW' | transloco}}" (click)="goToDetail(row.id!, 'view')"
-          *ngIf="access('view')">
-          <i class="fas fa-eye fa-sm"></i>
-        </button>
+          <button mat-mini-fab color="primary" class="secondary-action" (click)="goToDetail(row.id!, 'view')"
+            *ngIf="access('view')" matTooltip="{{'BUDGET.VIEW-RECORD.ACTIONS.VIEW' | transloco}}">
+            <i class="fas fa-eye fa-sm"></i>
+          </button>
 
-        <button color="primary" mat-mini-fab matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.EDIT' | transloco }}"
-          color="primary" (click)="goToDetail(row.id!, 'edit')" *ngIf="access('edit')">
-          <i class="fas fa-edit fa-sm"></i>
-        </button>
+          <button mat-mini-fab color="primary" (click)="goToDetail(row.id!, 'edit')" *ngIf="access('edit')"
+            matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.EDIT' | transloco }}">
+            <i class="fas fa-edit fa-sm"></i>
+          </button>
 
-        <!-- <button color="primary" class="secondary-action"
-          matTooltip="{{ 'BUDGET.VIEW-RECORD.ACTIONS.SHARE' | transloco }}" mat-mini-fab
-          (click)="openShareBudgetDialog(row)">
-          <i class="fas fa-share-alt fa-sm"></i>
-        </button> -->
+          <button mat-mini-fab color="primary" class="delete-btn" (click)="openShareBudgetDialog(row)">
+            <i class="fas fa-trash-alt fa-sm"></i>
+          </button>
+        </div>
+      </td>
+    </ng-container>
 
-        <button color="primary" class="delete-btn" matTooltip="Delete" mat-mini-fab
-          (click)="openShareBudgetDialog(row)">
-          <i class="fas fa-trash-alt fa-sm"></i>
-        </button>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
 
-        <!-- Will only be true on parent since does not get cascaded down below. -->
-        <!-- <div class="budget-btn-container" style="float: right; text-align: right">
-          <button class="btn-promote" (click)="promote()">{{ 'BUDGET.VIEW-RECORD.PROMOTE' | transloco }}</button>
-        </div> -->
-      </div>
-    </td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
-<mat-paginator [pageSizeOptions]="[10, 25, 100]" aria-label="Select page of users"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[10, 25, 100]"></mat-paginator>
+</div>

--- a/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.ts
+++ b/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.ts
@@ -1,15 +1,12 @@
-import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { MatTable, MatTableDataSource } from '@angular/material/table';
+import { Component, Input, Output, EventEmitter, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
-import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
+import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-
-import { SubSink } from 'subsink';
-import { Observable, tap } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Budget, BudgetRecord } from '@app/model/finance/planning/budgets';
-
 import { ShareBudgetModalComponent } from '../share-budget-modal/share-budget-modal.component';
 import { CreateBudgetModalComponent } from '../create-budget-modal/create-budget-modal.component';
 import { ChildBudgetsModalComponent } from '../../modals/child-budgets-modal/child-budgets-modal.component';
@@ -18,55 +15,25 @@ import { ChildBudgetsModalComponent } from '../../modals/child-budgets-modal/chi
   selector: 'app-budget-table',
   templateUrl: './budget-table.component.html',
   styleUrls: ['./budget-table.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-
 export class BudgetTableComponent {
-
-  private _sbS = new SubSink();
-
-  @Input() budgets$: Observable<{overview: BudgetRecord[], budgets: any[]}>;
+  @Input() budgets$!: Observable<{ overview: BudgetRecord[]; budgets: any[] }>;
   @Input() canPromote = false;
 
-  @Output() doPromote: EventEmitter<void> = new EventEmitter();
+  @Output() doPromote = new EventEmitter<void>();
 
-  dataSource = new MatTableDataSource();
+  dataSource = new MatTableDataSource<any>([]);
+  displayedColumns = ['name', 'status', 'startYear', 'duration', 'actions'];
 
-  displayedColumns: string[] = ['name', 'status', 'startYear', 'duration', 'actions'];
-
-  @ViewChild(MatPaginator) paginator: MatPaginator;
-  @ViewChild('sort', { static: true }) sort: MatSort;
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   overviewBudgets: BudgetRecord[] = [];
 
-  constructor(private _router$$: Router,
-              private _dialog: MatDialog,
-  ) { }
+  constructor(private _router: Router, private _dialog: MatDialog) {}
 
-  ngOnInit(): void {
-    this._sbS.sink = this.budgets$.pipe(tap((o) => {
-      this.overviewBudgets = o.overview;
-      this.dataSource.data = o.budgets;
-    })).subscribe();
-  }
-
-  /** 
- * Checks whether the user has access to a certain feature.
- * 
- * @TODO @IanOdhiambo9 - Please put proper access control architecture in place. 
- */
-  access(requested:any) 
-  {  
-    switch (requested) {
-      case 'view':
-      case 'clone':
-        return true; //budget.access.owner || budget.access.view || budget.access.edit;
-      case 'edit':
-        return true; // (budget.access.owner || budget.access.edit) && budget.status !== BudgetStatus.InUse && budget.status !== BudgetStatus.InUse;
-    }
-    return false;
-  }
-
-  ngAfterViewInit(): void {
+  ngAfterViewInit() {
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
   }
@@ -74,67 +41,53 @@ export class BudgetTableComponent {
   filterAccountRecords(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;
     this.dataSource.filter = filterValue.trim().toLowerCase();
-
-    if (this.dataSource.paginator) {
-      this.dataSource.paginator.firstPage();
-    }
+    this.dataSource.paginator?.firstPage();
   }
 
   promote() {
-    if (this.canPromote)
-      this.doPromote.emit();
+    if (this.canPromote) this.doPromote.emit();
   }
 
-  /** Open share screen to configure budget access. */
-  openShareBudgetDialog(parent: Budget | false): void 
-  {
+  openShareBudgetDialog(parent: Budget | false): void {
     this._dialog.open(ShareBudgetModalComponent, {
-      panelClass: 'no-pad-dialog',
       width: '600px',
-      data: parent != null ? parent : false
+      panelClass: 'no-pad-dialog',
+      data: parent || null
     });
   }
 
-  /** Open clone screen to clone and reconfigure budget. */
   openCloneBudgetDialog(parent: Budget | false): void {
     this._dialog.open(CreateBudgetModalComponent, {
-      height: 'fit-content',
       width: '600px',
-      data: parent != null ? parent : false
+      height: 'fit-content',
+      data: parent || null
     });
   }
 
-  openChildBudgetDialog(parent : Budget): void 
-  { 
-    let children: any = this.overviewBudgets.find((budget) => budget.budget.id === parent.id)!?.children;
-    children = children?.map((child) => child.budget)
+  openChildBudgetDialog(parent: Budget): void {
+    const children = this.overviewBudgets
+      .find(b => b.budget.id === parent.id)?.children?.map((c: any) => c.budget) ?? [];
+
     this._dialog.open(ChildBudgetsModalComponent, {
-      height: 'fit-content',
       minWidth: '600px',
-      data: {parent: parent, budgets: children}
+      height: 'fit-content',
+      data: { parent, budgets: children }
     });
   }
 
   goToDetail(budgetId: string, action: string) {
-    this._router$$.navigate(['budgets', budgetId, action]).then(() => this._dialog.closeAll());
+    this._router.navigate(['budgets', budgetId, action]).then(() => this._dialog.closeAll());
   }
 
-  deleteBudget(budget: Budget) {
-
+  translateStatus(status: number): string {
+    const map: Record<number, string> = {
+      1: 'BUDGET.STATUS.ACTIVE',
+      0: 'BUDGET.STATUS.DESIGN',
+      9: 'BUDGET.STATUS.NO-USE',
+      '-1': 'BUDGET.STATUS.DELETED'
+    };
+    return map[status] ?? '';
   }
 
-  translateStatus(status: number) {
-    switch (status) {
-      case 1:
-        return 'BUDGET.STATUS.ACTIVE';
-      case 0:
-        return 'BUDGET.STATUS.DESIGN';
-      case 9:
-        return 'BUDGET.STATUS.NO-USE';
-      case -1:
-        return 'BUDGET.STATUS.DELETED';
-      default:
-        return '';
-    }
-  }
+  access(_: string) { return true; }
 }

--- a/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.html
+++ b/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.html
@@ -1,8 +1,9 @@
 <app-page>
   <div>
     <kujali-finance-toolbar>
-      <kujali-finance-search-header-card header (toogleFilterEvent)='toogleFilter($event)'
-        (searchTableEvent)='applyFilter($event)' [tableData]="[]">
+      <kujali-finance-search-header-card header (toogleFilterEvent)="toogleFilter($event)"
+        (searchTableEvent)="applyFilter($event)" [tableData]="[]">
+
         <div add-new>
           <button mat-flat-button (click)="openDialog(false)" class="add-new">
             <i class="bi bi-plus-circle-fill"></i>
@@ -13,12 +14,11 @@
     </kujali-finance-toolbar>
 
     <div *ngIf="showFilter" class="filter-section">
-      <!-- <kujali-invoices-filter (filterChanged)='fieldsFilter($event)'>
-			</kujali-invoices-filter> -->
     </div>
 
     <div class="table-container">
-      <app-budget-table [budgets$]="allBudgets$"></app-budget-table>
+      <app-budget-table [budgets$]="budgetsForTable$" [canPromote]="true">
+      </app-budget-table>
     </div>
   </div>
 </app-page>

--- a/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.ts
+++ b/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.ts
@@ -1,108 +1,71 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-
-import { cloneDeep as ___cloneDeep, flatMap as __flatMap } from 'lodash';
-import { Observable, combineLatest, map, tap } from 'rxjs';
+import { Observable, combineLatest, map, shareReplay } from 'rxjs';
+import { cloneDeep as ___cloneDeep } from 'lodash';
 
 import { Logger } from '@iote/bricks-angular';
-
-import { Budget, BudgetRecord, BudgetStatus, OrgBudgetsOverview } from '@app/model/finance/planning/budgets';
-
+import { Budget, BudgetRecord, BudgetStatus } from '@app/model/finance/planning/budgets';
 import { BudgetsStore, OrgBudgetsStore } from '@app/state/finance/budgetting/budgets';
-
 import { CreateBudgetModalComponent } from '../../components/create-budget-modal/create-budget-modal.component';
-
 
 @Component({
   selector: 'app-select-budget',
   templateUrl: './select-budget.component.html',
-  styleUrls: ['./select-budget.component.scss', 
-              '../../components/budget-view-styles.scss'],
+  styleUrls: ['./select-budget.component.scss', '../../components/budget-view-styles.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-/** List of all active budgets on the system. */
-export class SelectBudgetPageComponent implements OnInit
-{
-  /** Overview which contains all budgets of an organisation */
-  overview$!: Observable<OrgBudgetsOverview>;
-  sharedBudgets$: Observable<any[]>;
+export class SelectBudgetPageComponent implements OnInit {
+  budgetsForTable$!: Observable<{ overview: BudgetRecord[]; budgets: any[] }>;
 
-  showFilter = false;
-
-  // budgetsLoaded: boolean = false;
-
-  allBudgets$: Observable<{overview: BudgetRecord[], budgets: any[]}>;
-
-  constructor(private _orgBudgets$$: OrgBudgetsStore,
-              private _budgets$$: BudgetsStore,
-              private _dialog: MatDialog,
-              private _logger: Logger) 
-  { }
+  constructor(
+    private _orgBudgets$$: OrgBudgetsStore,
+    private _budgets$$: BudgetsStore,
+    private _dialog: MatDialog,
+    private _logger: Logger
+  ) {}
 
   ngOnInit() {
-    this.overview$ = this._orgBudgets$$.get();
-    this.sharedBudgets$ = this._budgets$$.get();
+    const overview$ = this._orgBudgets$$.get().pipe(shareReplay(1));
+    const sharedBudgets$ = this._budgets$$.get().pipe(shareReplay(1));
 
-    this.allBudgets$ = combineLatest([this.overview$, this._budgets$$.get()])
-                      .pipe(map(([overview, budgets]) => {return {overview: __flatMap(overview), budgets: __flatMap(budgets)}}),
-                            map((overview) => {
-                              const trBudgets = overview.budgets.map((budget: any) => {budget['endYear'] = budget.startYear + budget.duration - 1; return budget;})
-                              // this.budgetsLoaded = true;
-                              return {overview: overview.overview, budgets: trBudgets}
-                            }));
+    this.budgetsForTable$ = combineLatest([overview$, sharedBudgets$]).pipe(
+      map(([overview, shared]) => ({
+        overview: (overview as any).flat?.() ?? overview,
+        budgets: (shared as any).flat?.() ?? shared
+      })),
+      map(({ overview, budgets }) => ({
+        overview,
+        budgets: budgets.map((b: any) => ({
+          ...b,
+          endYear: b.startYear + b.duration - 1
+        }))
+      })),
+      shareReplay(1)
+    );
   }
 
-  applyFilter(event: Event) {
-    const filterValue = (event.target as HTMLInputElement).value;
-    // this.dataSource.filter = filterValue.trim().toLowerCase();
-  }
-
-  fieldsFilter(value: (Invoice) => boolean) {    
-    // this.filter$$.next(value);
-  }
-
-  toogleFilter(value) {
-    // this.showFilter = value
-  }
-
-  openDialog(parent : Budget | false): void 
-  {
-    const dialog = this._dialog.open(CreateBudgetModalComponent, {
+  openDialog(parent: Budget | false): void {
+    this._dialog.open(CreateBudgetModalComponent, {
       height: 'fit-content',
       width: '600px',
-      data: parent != null ? parent : false
+      data: parent || null
     });
-
-    dialog.afterClosed().subscribe(() => {
-      // Dialog after action
-    })
   }
 
-  /** 
-   * @TODO - Review and fix
-   * Returns true if the budget can be activated */
   canPromote(record: BudgetRecord) {
-    // Get's set on Budget Read from user privileges and budget status.
     return (record.budget as any).canBeActivated;
   }
 
-  /** Activate budget -> Promote to be used in  */
-  setActive(record: BudgetRecord) 
-  {
+  setActive(record: BudgetRecord) {
     const toSave = ___cloneDeep(record.budget);
-
-    // Clean up budget record values.
     delete (toSave as any).canBeActivated;
     delete (toSave as any).access;
-
-    // Set Active
     toSave.status = BudgetStatus.InUse;
 
-    (<any> record).updating = true;
-    // Fire update
-    this._budgets$$.update(toSave)
-      .subscribe(() => {
-        (<any> record).updating = false;
-        this._logger.log(() => `Updated Budget with id ${toSave.id}. Set as an active budget for this org.`) 
-      });
+    (record as any).updating = true;
+    this._budgets$$.update(toSave).subscribe(() => {
+      (record as any).updating = false;
+      this._logger.log(() => `Budget ${toSave.id} is now active`);
+    });
   }
 }


### PR DESCRIPTION
The project is still on Angular 15 and Signals are not available yet. I removed all manual subscriptions and component state so the parent component only passes one stream down and the table component now receives the data once in the template and uses it from there.
Signals are better for this kind of list UI because you can read values directly without the async pipe. Only the changed row updates and the app can run without Zone.js making it faster and smoother than the old RxJS  plus async pipe.
The big style difference is that RxJS pushes new values to you whenever they arrive while signals let you just read the current value any time and Angular automatically knows what depends on it.
An Observable is a stream that can give zero, one or many values over time when subscribed to while a signal always has exactly one current value right now and instantly tells the template when that value actually changes.
I have built a medium-sized internal dashboard with Vue 3 and the Composition API with ref/reactive. The feeling is very close to what Signals give in Angular. For normal screen state and lists it was easier and faster to reason about than heavy RxJS setups, though RxJS is still handy when you have many async operations that need to be combined in complicated ways. The refactor I have done gives the same simple and clean feeling into the current Angular 15 code without breaking any rules.

