### PR TITLE
Feature: Add Note to Budget Command

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -77,6 +77,7 @@
     "functions-pubsub": "libs/functions/pubsub",
     "kujali": "apps/kujali",
     "kujali-functions": "apps/kujali-functions",
+    "model-budgetting-notes-budget-notes": "libs/model/budgetting/notes/budget-notes",
     "model-data-db": "libs/model/data/db",
     "model-finance-accounts-main": "libs/model/finance/accounts/main",
     "model-finance-activities-base": "libs/model/finance/activities/base",
@@ -128,6 +129,5 @@
     "util-ngfi-infinite-scroll": "libs/util/ngfi/infinite-scroll",
     "util-ngfi-multi-lang": "libs/util/ngfi/multi-lang",
     "util-ngfi-state": "libs/util/ngfi/state"
-  },
-  "defaultProject": "kujali"
+  }
 }

--- a/libs/model/budgetting/notes/budget-notes/.babelrc
+++ b/libs/model/budgetting/notes/budget-notes/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/model/budgetting/notes/budget-notes/.eslintrc.json
+++ b/libs/model/budgetting/notes/budget-notes/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/model/budgetting/notes/budget-notes/README.md
+++ b/libs/model/budgetting/notes/budget-notes/README.md
@@ -1,0 +1,11 @@
+# model-budgetting-notes-budget-notes
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test model-budgetting-notes-budget-notes` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint model-budgetting-notes-budget-notes` to execute the lint via [ESLint](https://eslint.org/).

--- a/libs/model/budgetting/notes/budget-notes/jest.config.ts
+++ b/libs/model/budgetting/notes/budget-notes/jest.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+export default {
+  displayName: 'model-budgetting-notes-budget-notes',
+  preset: '../../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory:
+    '../../../../../coverage/libs/model/budgetting/notes/budget-notes',
+};

--- a/libs/model/budgetting/notes/budget-notes/project.json
+++ b/libs/model/budgetting/notes/budget-notes/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "model-budgetting-notes-budget-notes",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/model/budgetting/notes/budget-notes/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/model/budgetting/notes/budget-notes/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/model/budgetting/notes/budget-notes/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/model/budgetting/notes/budget-notes/src/index.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/model-budgetting-notes-budget-notes';

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.command.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.command.ts
@@ -1,0 +1,10 @@
+export type AddNoteToBudgetResult = void;
+
+export class AddNoteToBudgetCommand {
+  constructor(
+    public readonly budgetId: string,
+    public readonly content: string,
+    public readonly createdBy: string,
+    public readonly createdAt: number = Date.now()
+  ) {}
+}

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.handler.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.handler.ts
@@ -1,0 +1,50 @@
+import { ICommandHandler } from './i-command-handler';
+import { AddNoteToBudgetCommand } from './add-note.command';
+
+type BudgetNotesRepo = {
+  addNote: (
+    budgetId: string,
+    note: { content: string; createdBy: string; createdAt: number }
+  ) => Promise<void> | void;
+};
+
+type Toolkit = {
+  getRepository: (key: 'budgetNotes' | string) => BudgetNotesRepo;
+};
+
+export class AddNoteToBudgetHandler
+  implements ICommandHandler<AddNoteToBudgetCommand>
+{
+  async execute(
+    command: AddNoteToBudgetCommand,
+    toolkit?: Toolkit
+  ): Promise<void> {
+    if (!command) {
+      throw new Error('Command is required');
+    }
+
+    const { budgetId, content, createdBy, createdAt } = command;
+
+    if (typeof budgetId !== 'string' || budgetId.trim().length === 0) {
+      throw new Error('budgetId must not be empty');
+    }
+    if (typeof content !== 'string' || content.trim().length === 0) {
+      throw new Error('content must not be empty');
+    }
+    if (typeof createdBy !== 'string' || createdBy.trim().length === 0) {
+      throw new Error('createdBy must not be empty');
+    }
+
+    const repo = toolkit?.getRepository?.('budgetNotes') as
+      | BudgetNotesRepo
+      | undefined;
+
+    if (!repo || typeof repo.addNote !== 'function') {
+      throw new Error('budgetNotes repository is not available');
+    }
+
+    await Promise.resolve(
+      repo.addNote(budgetId, { content, createdBy, createdAt })
+    );
+  }
+}

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/i-command-handler.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/i-command-handler.ts
@@ -1,0 +1,3 @@
+export interface ICommandHandler<TCommand> {
+  execute(command: TCommand, toolkit?: any): Promise<void>;
+}

--- a/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.spec.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.spec.ts
@@ -1,0 +1,9 @@
+import { modelBudgettingNotesBudgetNotes } from './model-budgetting-notes-budget-notes';
+
+describe('modelBudgettingNotesBudgetNotes', () => {
+  it('should work', () => {
+    expect(modelBudgettingNotesBudgetNotes()).toEqual(
+      'model-budgetting-notes-budget-notes'
+    );
+  });
+});

--- a/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.ts
@@ -1,0 +1,3 @@
+export function modelBudgettingNotesBudgetNotes(): string {
+  return 'model-budgetting-notes-budget-notes';
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.lib.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.spec.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -185,6 +185,9 @@
         "libs/functions/finance/manage/payments/src/index.ts"
       ],
       "@app/functions/pubsub": ["libs/functions/pubsub/src/index.ts"],
+      "@app/model/budgetting/notes/budget-notes": [
+        "libs/model/budgetting/notes/budget-notes/src/index.ts"
+      ],
       "@app/model/common/config": ["libs/model/common/config/src/index.ts"],
       "@app/model/common/user": ["libs/model/common/user/src/index.ts"],
       "@app/model/data/db": ["libs/model/data/db/src/index.ts"],


### PR DESCRIPTION
## **Summary**
This PR introduces a focused domain module for adding notes to a budget. It implements a Command/Handler pattern within the Nx monorepo, keeping the domain pure, framework-agnostic, and reusable across multiple application services.

---

## **What’s Included**
**Library:** `libs/model/budgetting/notes/budget-notes`

**Domain files added:**
- `domain/add-note.command.ts` — `AddNoteToBudgetCommand` and `AddNoteToBudgetResult = void`
- `domain/i-command-handler.ts` — generic `ICommandHandler`
- `domain/add-note.handler.ts` — `AddNoteToBudgetHandler` with:
  - Input validation  
  - Repository interaction via `toolkit.getRepository('budgetNotes')`

Additional notes:
- Code formatted with Nx tools  
- Atomic commit history  
- No build/run executed as per assessment instructions  

---

## **Understanding of Backend Development Process**
- **Separation of concerns:** Domain logic stays pure; infrastructure layers (HTTP, messaging, DB) wrap around the domain.
- **Command/Handler (CQRS style):**  
  - Command = intent + required data  
  - Handler = executes the use case, validates inputs, and interacts with persistence  
- **Ports and adapters:**  
  The handler relies on `toolkit.getRepository('budgetNotes')` as an abstract port, allowing easy swapping of real vs fake repositories.
- **Validation at the edge:** Ensures `budgetId`, `content`, and `createdBy` are present and valid.
- **Explicit data model:** `AddNoteToBudgetCommand` contains all required fields; `createdAt` defaults to `Date.now()`.
- **Monorepo structure:** Domain logic lives in `libs/` for stability; Nx rebuilds dependents automatically.

---

## **Design Choices**
- **`AddNoteToBudgetCommand`:**  
  Minimal fields (`budgetId`, `content`, `createdBy`, `createdAt`), clear intent, default timestamp.
- **`ICommandHandler`:**  
  Simple `execute(command, toolkit?) => Promise<void>` interface is lightweight and bus-friendly.
- **`AddNoteToBudgetHandler`:**  
  - Validates incoming fields  
  - Fetches `budgetNotes` repository from toolkit  
  - Calls `repo.addNote(budgetId, { content, createdBy, createdAt })`  
  - Throws clear errors for missing dependencies  
- **Result type:** `void` matches write-side behavior; queries should handle retrieval.

---

## **Deployment Approach (Based on Repo Architecture)**
- This library is domain-only; deployment happens via an app under `apps/` (API, worker, serverless function, or command bus).
- The consuming application would:
  1. Import the domain library  
  2. Register a concrete `budgetNotes` repository adapter  
  3. Pass dependencies via the toolkit  
  4. Expose an endpoint/event that maps to the handler  

### **Nx Integration**
- The app automatically bundles this library during `nx build`.
- CI/CD should lint → test → build → package.

### **Configuration**
- Use environment variables for repo URLs/credentials.
- Ensure DI/composition maps `toolkit.getRepository('budgetNotes')` correctly.

---

## **Serverless Deployment & Scaling**
- **Fit:** This handler is stateless and pure, ideal for AWS Lambda, Azure Functions, GCP Cloud Functions, or Firebase Functions.
- **Adapter:** Serverless function converts an incoming event → `AddNoteToBudgetCommand` → invokes handler with a toolkit containing a concrete repository.
- **Scaling considerations:**  
  - Horizontal scaling per request  
  - Ensure storage layer supports concurrent writes  
  - Use idempotency keys for at-least-once delivery systems  
  - Minimize cold start impact; this small domain library helps  
- **Observability:** Add structured logs + measure repo latency in production.

---

## **Notes / Trade-offs**
- PR intentionally excludes runtime wiring, this focuses on domain building blocks only.
- Repository interface remains minimal to keep the domain decoupled.
- **Next steps:**  
  - Implement concrete `budgetNotes` repository  
  - Register handler in an app under `apps/`  
  - Expose HTTP/event endpoints  
  - Add unit/integration tests  

