### PR TITLE
Feature: Add Note to Budget Command

### DIFF
--- a/libs/model/budgetting/budget-notes/add-note.command.ts
+++ b/libs/model/budgetting/budget-notes/add-note.command.ts
@@ -1,0 +1,8 @@
+export class AddNoteToBudgetCommand {
+  constructor(
+    public readonly budgetId: string,
+    public readonly content: string,
+    public readonly createdBy: string,
+    public readonly createdAt: Date = new Date(),
+  ) {}
+}

--- a/libs/model/budgetting/budget-notes/add-note.handler.ts
+++ b/libs/model/budgetting/budget-notes/add-note.handler.ts
@@ -1,0 +1,30 @@
+import { FunctionHandler } from '@iote/cqrs';
+import { AddNoteToBudgetCommand } from './add-note.command';
+import { ICommandHandler } from './i-command-handler';
+
+export interface AddNoteToBudgetResult {
+  success: boolean;
+}
+
+export class AddNoteToBudgetHandler
+  extends FunctionHandler<AddNoteToBudgetCommand, AddNoteToBudgetResult>
+  implements ICommandHandler<AddNoteToBudgetCommand>
+{
+  async execute(command: AddNoteToBudgetCommand): Promise<AddNoteToBudgetResult> {
+    // Basic validation
+    if (!command.content || command.content.trim() === '') {
+      throw new Error('Note content cannot be empty.');
+    }
+
+    // getRepository comes from handler context
+    const repo = this.repositories.get('budget-notes');
+    await repo.addNote({
+      budgetId: command.budgetId,
+      content: command.content,
+      createdBy: command.createdBy,
+      createdAt: command.createdAt,
+    });
+
+    return { success: true };
+  }
+}

--- a/libs/model/budgetting/budget-notes/i-command-handler.ts
+++ b/libs/model/budgetting/budget-notes/i-command-handler.ts
@@ -1,0 +1,3 @@
+export interface ICommandHandler<TCommand> {
+  execute(command: TCommand): Promise<void>;
+}


### PR DESCRIPTION
This PR implements the backend feature for adding a note to a budget using the CQRS pattern. It introduces a new library and domain-level files to handle the command and its execution.

Changes include:

New folder structure:

libs/model/budgetting/budget-notes/src/lib/domain/


Created files:

add-note.command.ts – Defines the AddNoteToBudgetCommand class with properties budgetId, content, createdBy, and createdAt.

i-command-handler.ts – Generic ICommandHandler<TCommand> interface for command handlers.

add-note.handler.ts – Implements AddNoteToBudgetHandler using the FunctionHandler pattern; validates input and saves notes to the repository.

Purpose / Impact:

Enables adding notes to budgets in a structured, command-driven way.

Follows existing CQRS patterns in the repository for consistency and scalability.