### PR TITLE
Refactor: Modernize budget viewer state with Signals

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -77,6 +77,7 @@
     "functions-pubsub": "libs/functions/pubsub",
     "kujali": "apps/kujali",
     "kujali-functions": "apps/kujali-functions",
+    "model-budgetting-notes-budget-notes": "libs/model/budgetting/notes/budget-notes",
     "model-data-db": "libs/model/data/db",
     "model-finance-accounts-main": "libs/model/finance/accounts/main",
     "model-finance-activities-base": "libs/model/finance/activities/base",

--- a/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.html
+++ b/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.html
@@ -4,7 +4,7 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef mat-sort-header> Budget Name </th>
     <td mat-cell *matCellDef="let row">
-      {{row.name ? row.name : '-' }} <span *ngIf="row.childrenList?.length > 0" class="badge primary"
+      {{row.name ? row.name : '-' }} <span *ngIf="row.childrenList?.length" class="badge primary"
         (click)="openChildBudgetDialog(row)"> Linked Budgets ({{ row?.childrenList?.length }}) </span>
     </td>
   </ng-container>

--- a/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.ts
+++ b/libs/features/budgetting/budgets/src/lib/components/budget-table/budget-table.component.ts
@@ -1,9 +1,11 @@
-import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, Output,inject, effect, Signal, ViewChild } from '@angular/core';
 import { MatTable, MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
 import { Router } from '@angular/router';
+
+import { signal } from '@angular/core';
 
 import { SubSink } from 'subsink';
 import { Observable, tap } from 'rxjs';
@@ -22,9 +24,7 @@ import { ChildBudgetsModalComponent } from '../../modals/child-budgets-modal/chi
 
 export class BudgetTableComponent {
 
-  private _sbS = new SubSink();
-
-  @Input() budgets$: Observable<{overview: BudgetRecord[], budgets: any[]}>;
+  @Input() budgets!: Signal<{ overview: BudgetRecord[], budgets: any[] }>;
   @Input() canPromote = false;
 
   @Output() doPromote: EventEmitter<void> = new EventEmitter();
@@ -36,18 +36,24 @@ export class BudgetTableComponent {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild('sort', { static: true }) sort: MatSort;
 
-  overviewBudgets: BudgetRecord[] = [];
+  overviewBudgets = signal<BudgetRecord[]>([]);
 
-  constructor(private _router$$: Router,
-              private _dialog: MatDialog,
-  ) { }
+  private dialog = inject(MatDialog);
+  private router = inject(Router);
 
-  ngOnInit(): void {
-    this._sbS.sink = this.budgets$.pipe(tap((o) => {
-      this.overviewBudgets = o.overview;
-      this.dataSource.data = o.budgets;
-    })).subscribe();
+    constructor() {
+    effect(() => {
+      const data = this.budgets();
+
+      if (!data) return;
+
+      this.overviewBudgets.set(data.overview);
+
+      // table data
+      this.dataSource.data = data.budgets || [];
+    });
   }
+
 
   /** 
  * Checks whether the user has access to a certain feature.
@@ -86,9 +92,8 @@ export class BudgetTableComponent {
   }
 
   /** Open share screen to configure budget access. */
-  openShareBudgetDialog(parent: Budget | false): void 
-  {
-    this._dialog.open(ShareBudgetModalComponent, {
+  openShareBudgetDialog(parent: Budget | false) {
+    this.dialog.open(ShareBudgetModalComponent, {
       panelClass: 'no-pad-dialog',
       width: '600px',
       data: parent != null ? parent : false
@@ -96,19 +101,18 @@ export class BudgetTableComponent {
   }
 
   /** Open clone screen to clone and reconfigure budget. */
-  openCloneBudgetDialog(parent: Budget | false): void {
-    this._dialog.open(CreateBudgetModalComponent, {
+  openCloneBudgetDialog(parent: Budget | false) {
+    this.dialog.open(CreateBudgetModalComponent, {
       height: 'fit-content',
       width: '600px',
       data: parent != null ? parent : false
     });
   }
 
-  openChildBudgetDialog(parent : Budget): void 
-  { 
+  openChildBudgetDialog(parent : Budget) { 
     let children: any = this.overviewBudgets.find((budget) => budget.budget.id === parent.id)!?.children;
     children = children?.map((child) => child.budget)
-    this._dialog.open(ChildBudgetsModalComponent, {
+    this.dialog.open(ChildBudgetsModalComponent, {
       height: 'fit-content',
       minWidth: '600px',
       data: {parent: parent, budgets: children}
@@ -116,7 +120,7 @@ export class BudgetTableComponent {
   }
 
   goToDetail(budgetId: string, action: string) {
-    this._router$$.navigate(['budgets', budgetId, action]).then(() => this._dialog.closeAll());
+    this.router.navigate(['budgets', budgetId, action]).then(() => this.dialog.closeAll());
   }
 
   deleteBudget(budget: Budget) {

--- a/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.html
+++ b/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.html
@@ -18,7 +18,7 @@
     </div>
 
     <div class="table-container">
-      <app-budget-table [budgets$]="allBudgets$"></app-budget-table>
+      <app-budget-table [budgets]="allBudgets"></app-budget-table>
     </div>
   </div>
 </app-page>

--- a/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.ts
+++ b/libs/features/budgetting/budgets/src/lib/pages/select-budget/select-budget.component.ts
@@ -1,62 +1,80 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  inject,
+  signal,
+  computed,
+  effect,
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 import { cloneDeep as ___cloneDeep, flatMap as __flatMap } from 'lodash';
 import { Observable, combineLatest, map, tap } from 'rxjs';
 
 import { Logger } from '@iote/bricks-angular';
 
-import { Budget, BudgetRecord, BudgetStatus, OrgBudgetsOverview } from '@app/model/finance/planning/budgets';
+import {
+  Budget,
+  BudgetRecord,
+  BudgetStatus,
+  OrgBudgetsOverview,
+} from '@app/model/finance/planning/budgets';
 
-import { BudgetsStore, OrgBudgetsStore } from '@app/state/finance/budgetting/budgets';
+import {
+  BudgetsStore,
+  OrgBudgetsStore,
+} from '@app/state/finance/budgetting/budgets';
 
 import { CreateBudgetModalComponent } from '../../components/create-budget-modal/create-budget-modal.component';
-
 
 @Component({
   selector: 'app-select-budget',
   templateUrl: './select-budget.component.html',
-  styleUrls: ['./select-budget.component.scss', 
-              '../../components/budget-view-styles.scss'],
+  styleUrls: [
+    './select-budget.component.scss',
+    '../../components/budget-view-styles.scss',
+  ],
 })
 /** List of all active budgets on the system. */
-export class SelectBudgetPageComponent implements OnInit
-{
+export class SelectBudgetPageComponent {
+
+  private _orgBudgets = inject(OrgBudgetsStore);
+  private _budgets = inject(BudgetsStore);
+  private _dialog = inject(MatDialog);
+  private _logger: Logger;
   /** Overview which contains all budgets of an organisation */
-  overview$!: Observable<OrgBudgetsOverview>;
-  sharedBudgets$: Observable<any[]>;
+  overview = toSignal(this._orgBudgets.get(), { initialValue: null });
+  sharedBudgets = toSignal(this._budgets.get(), { initialValue: [] });
 
   showFilter = false;
 
   // budgetsLoaded: boolean = false;
 
-  allBudgets$: Observable<{overview: BudgetRecord[], budgets: any[]}>;
+  allBudgets$: Observable<{ overview: BudgetRecord[]; budgets: any[] }>;
 
-  constructor(private _orgBudgets$$: OrgBudgetsStore,
-              private _budgets$$: BudgetsStore,
-              private _dialog: MatDialog,
-              private _logger: Logger) 
-  { }
+    allBudgets = computed(() => {
+    const overview = this.overview();
+    const budgets = this.sharedBudgets();
 
-  ngOnInit() {
-    this.overview$ = this._orgBudgets$$.get();
-    this.sharedBudgets$ = this._budgets$$.get();
+    if (!overview) return { overview: [], budgets: [] };
 
-    this.allBudgets$ = combineLatest([this.overview$, this._budgets$$.get()])
-                      .pipe(map(([overview, budgets]) => {return {overview: __flatMap(overview), budgets: __flatMap(budgets)}}),
-                            map((overview) => {
-                              const trBudgets = overview.budgets.map((budget: any) => {budget['endYear'] = budget.startYear + budget.duration - 1; return budget;})
-                              // this.budgetsLoaded = true;
-                              return {overview: overview.overview, budgets: trBudgets}
-                            }));
-  }
+    const flatOverview = __flatMap(overview);
+    const flatBudgets = __flatMap(budgets).map((budget: any) => {
+      budget['endYear'] = budget.startYear + budget.duration - 1;
+      return budget;
+    });
+
+    return { overview: flatOverview, budgets: flatBudgets };
+  });
 
   applyFilter(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;
     // this.dataSource.filter = filterValue.trim().toLowerCase();
   }
 
-  fieldsFilter(value: (Invoice) => boolean) {    
+  fieldsFilter(value: (Invoice) => boolean) {
     // this.filter$$.next(value);
   }
 
@@ -64,20 +82,19 @@ export class SelectBudgetPageComponent implements OnInit
     // this.showFilter = value
   }
 
-  openDialog(parent : Budget | false): void 
-  {
+  openDialog(parent: Budget | false): void {
     const dialog = this._dialog.open(CreateBudgetModalComponent, {
       height: 'fit-content',
       width: '600px',
-      data: parent != null ? parent : false
+      data: parent != null ? parent : false,
     });
 
     dialog.afterClosed().subscribe(() => {
       // Dialog after action
-    })
+    });
   }
 
-  /** 
+  /**
    * @TODO - Review and fix
    * Returns true if the budget can be activated */
   canPromote(record: BudgetRecord) {
@@ -86,8 +103,7 @@ export class SelectBudgetPageComponent implements OnInit
   }
 
   /** Activate budget -> Promote to be used in  */
-  setActive(record: BudgetRecord) 
-  {
+  setActive(record: BudgetRecord) {
     const toSave = ___cloneDeep(record.budget);
 
     // Clean up budget record values.
@@ -97,12 +113,14 @@ export class SelectBudgetPageComponent implements OnInit
     // Set Active
     toSave.status = BudgetStatus.InUse;
 
-    (<any> record).updating = true;
+    (<any>record).updating = true;
     // Fire update
-    this._budgets$$.update(toSave)
-      .subscribe(() => {
-        (<any> record).updating = false;
-        this._logger.log(() => `Updated Budget with id ${toSave.id}. Set as an active budget for this org.`) 
-      });
+    this._budgets.update(toSave).subscribe(() => {
+      (<any>record).updating = false;
+      this._logger.log(
+        () =>
+          `Updated Budget with id ${toSave.id}. Set as an active budget for this org.`
+      );
+    });
   }
 }

--- a/libs/model/budgetting/notes/budget-notes/.babelrc
+++ b/libs/model/budgetting/notes/budget-notes/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/model/budgetting/notes/budget-notes/.eslintrc.json
+++ b/libs/model/budgetting/notes/budget-notes/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/model/budgetting/notes/budget-notes/README.md
+++ b/libs/model/budgetting/notes/budget-notes/README.md
@@ -1,0 +1,11 @@
+# model-budgetting-notes-budget-notes
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test model-budgetting-notes-budget-notes` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint model-budgetting-notes-budget-notes` to execute the lint via [ESLint](https://eslint.org/).

--- a/libs/model/budgetting/notes/budget-notes/jest.config.ts
+++ b/libs/model/budgetting/notes/budget-notes/jest.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+export default {
+  displayName: 'model-budgetting-notes-budget-notes',
+  preset: '../../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory:
+    '../../../../../coverage/libs/model/budgetting/notes/budget-notes',
+};

--- a/libs/model/budgetting/notes/budget-notes/project.json
+++ b/libs/model/budgetting/notes/budget-notes/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "model-budgetting-notes-budget-notes",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/model/budgetting/notes/budget-notes/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/model/budgetting/notes/budget-notes/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/model/budgetting/notes/budget-notes/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/model/budgetting/notes/budget-notes/src/index.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/model-budgetting-notes-budget-notes';
+export * from './lib/domain/add-note.command';
+export * from './lib/domain/add-note.handler';
+export * from './lib/domain/command-handler.interface';
+export * from './lib/domain/add-note.result';

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.command.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.command.ts
@@ -1,0 +1,7 @@
+export class AddNoteToBudgetCommand {
+  constructor(
+    public budgetId: string,
+    public content: string,
+    public createdBy: string
+  ) {}
+}

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.handler.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.handler.ts
@@ -1,0 +1,35 @@
+import { AddNoteToBudgetCommand } from './add-note.command';
+import { FunctionHandler, FunctionContext} from '@ngfi/functions';
+import { AddNoteToBudgetResult } from './add-note.result';
+
+export class AddNoteToBudgetHandler
+  extends FunctionHandler<AddNoteToBudgetCommand, AddNoteToBudgetResult>
+{
+ async execute(
+    command: AddNoteToBudgetCommand,
+    context: FunctionContext,
+    tools: {getRepository: (collection: string) => any}
+  ): Promise<AddNoteToBudgetResult> 
+  {
+    const { budgetId, content, createdBy } = command;
+
+    if (!budgetId) {
+      throw new Error('Budget ID is required.');
+    }
+
+    if (!content || content.trim().length === 0) {
+      throw new Error('Note content cannot be empty.');
+    }
+
+    const repo = tools.getRepository('budget');
+
+    const noteId = await repo.addNote({
+      budgetId,
+      content,
+      createdBy,
+      createdAt: Date.now()
+    });
+
+    return new AddNoteToBudgetResult(true, noteId);
+  }
+}

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.result.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/add-note.result.ts
@@ -1,0 +1,6 @@
+export class AddNoteToBudgetResult {
+  constructor(
+    public success: boolean,
+    public noteId?: string
+  ) {}
+}

--- a/libs/model/budgetting/notes/budget-notes/src/lib/domain/command.handler.interface.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/domain/command.handler.interface.ts
@@ -1,0 +1,3 @@
+export interface ICommandHandler<TCommand> {
+  execute(command: TCommand): Promise<void>;
+}

--- a/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.spec.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.spec.ts
@@ -1,0 +1,9 @@
+import { modelBudgettingNotesBudgetNotes } from './model-budgetting-notes-budget-notes';
+
+describe('modelBudgettingNotesBudgetNotes', () => {
+  it('should work', () => {
+    expect(modelBudgettingNotesBudgetNotes()).toEqual(
+      'model-budgetting-notes-budget-notes'
+    );
+  });
+});

--- a/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.ts
+++ b/libs/model/budgetting/notes/budget-notes/src/lib/model-budgetting-notes-budget-notes.ts
@@ -1,0 +1,3 @@
+export function modelBudgettingNotesBudgetNotes(): string {
+  return 'model-budgetting-notes-budget-notes';
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.lib.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/model/budgetting/notes/budget-notes/tsconfig.spec.json
+++ b/libs/model/budgetting/notes/budget-notes/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -185,6 +185,9 @@
         "libs/functions/finance/manage/payments/src/index.ts"
       ],
       "@app/functions/pubsub": ["libs/functions/pubsub/src/index.ts"],
+      "@app/model/budgetting/notes/budget-notes": [
+        "libs/model/budgetting/notes/budget-notes/src/index.ts"
+      ],
       "@app/model/common/config": ["libs/model/common/config/src/index.ts"],
       "@app/model/common/user": ["libs/model/common/user/src/index.ts"],
       "@app/model/data/db": ["libs/model/data/db/src/index.ts"],


### PR DESCRIPTION
For this PR, I refactored the budget UI components from an Observable-driven pattern to Angular Signals. I replaced constructor DI with inject(), converted the consumed Observables using toSignal(), moved derived logic into computed(), and replaced subscription handling with a single effect(). The child component was also updated to accept a Signal input and remove all RxJS subscription logic.

This modernization simplifies state flow, removes memory-leak risks, and enables fine-grained UI updates.

The benefit of using signals is:
- No subscriptions or cleanup needed
- Cleaner UI state management
- Only the parts of the UI depending on a specific signal re-render.
-  It is easier to follow compared to pipelines of RxJS operators.

The difference in the coding styles is RxJS uses a stream-based approach focused on composing asynchronous event sequences with operators like map, switchMap, combineLatest, etc while signals use a state-based approach where each piece of data is a reactive value (signal, computed, effect) that updates synchronously.

Observables emit many values over time and require a subscription to start producing values. Signals hold a single value, update synchronously, and automatically notify dependent computations. Observables remain ideal for API streams and asynchronous workflows. Signals are better suited for component/UI state.

From mobile development, I’ve worked extensively with Kotlin Flow / StateFlow in Jetpack Compose and Flutter’s reactive state tools like mutableStateOf and Provider. These follow a declarative UI model where the UI reacts automatically to state changes. Angular Signals feel very similar to mutableStateOf in Compose. Compared to Flow or BLoC, Signals provide a lighter mental model for component-level state and reduce the overhead of managing async streams for simple UI rendering.